### PR TITLE
fix the polymorphic association bug

### DIFF
--- a/lib/second_level_cache/active_record/has_one_association.rb
+++ b/lib/second_level_cache/active_record/has_one_association.rb
@@ -12,7 +12,11 @@ module SecondLevelCache
 
         def find_target_with_second_level_cache
           return find_target_without_second_level_cache unless klass.second_level_cache_enabled?
-          cache_record = klass.fetch_by_uniq_key(owner[reflection.active_record_primary_key], reflection.foreign_key)
+          if reflection.options[:as]
+            cache_record = klass.fetch_by_uniq_keys({reflection.foreign_key => owner[reflection.active_record_primary_key], reflection.type => owner.class.base_class.name})
+          else
+            cache_record = klass.fetch_by_uniq_key(owner[reflection.active_record_primary_key], reflection.foreign_key)
+          end
           return cache_record.tap{|record| set_inverse_instance(record)} if cache_record
 
           record = find_target_without_second_level_cache


### PR DESCRIPTION
while you have an Image model mount as imageable to multiple models, say an article with id to be 5, it would generate a cache key like "uniq_key_Image_imageable_id_5", which is wrong as the type is missing.
After the fix, it should be "uniq_key_Image_imageable_id_5,imageable_type_Article".
