### PR TITLE
cache_uniq_key fix nil error

### DIFF
--- a/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
+++ b/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
@@ -30,7 +30,7 @@ module SecondLevelCache
       
       def cache_uniq_key(where_values)
         ext_key = where_values.collect { |k,v|
-          v = Digest::MD5.hexdigest(v) if v.size >= 32
+          v = Digest::MD5.hexdigest(v) if v && v.size >= 32
           [k,v].join("_")
         }.join(",")
         "uniq_key_#{self.name}_#{ext_key}"

--- a/test/fetch_by_uniq_key_test.rb
+++ b/test/fetch_by_uniq_key_test.rb
@@ -10,6 +10,7 @@ class FetchByUinqKeyTest < ActiveSupport::TestCase
   def test_cache_uniq_key
     assert_equal User.send(:cache_uniq_key, { :name => "hooopo" } ), "uniq_key_User_name_hooopo"
     assert_equal User.send(:cache_uniq_key, { :foo => 1, :bar => 2 } ), "uniq_key_User_foo_1,bar_2"
+    assert_equal User.send(:cache_uniq_key, { :foo => 1, :bar => nil } ), "uniq_key_User_foo_1,bar_"
     long_val = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     assert_equal User.send(:cache_uniq_key, { :foo => 1, :bar => long_val } ), "uniq_key_User_foo_1,bar_#{Digest::MD5.hexdigest(long_val)}"
   end


### PR DESCRIPTION
`cache_uniq_key` method, if value=nil, will raise exception
