### PR TITLE
Load ActiveRecord::Base extensions inside Rails initialization process.

### DIFF
--- a/lib/second_level_cache/active_record.rb
+++ b/lib/second_level_cache/active_record.rb
@@ -8,11 +8,15 @@ require 'second_level_cache/active_record/belongs_to_association'
 require 'second_level_cache/active_record/has_one_association'
 require 'second_level_cache/active_record/preloader'
 
-ActiveRecord::Base.send(:include, SecondLevelCache::Mixin)
-ActiveRecord::Base.send(:include, SecondLevelCache::ActiveRecord::Base)
-ActiveRecord::Base.send(:extend, SecondLevelCache::ActiveRecord::FetchByUniqKey)
+class SecondLevelCache::ActiveRecord::Railtie < Rails::Railtie
+  initializer "second_level_cache.active_record.initialization" do
+    ActiveRecord::Base.send(:include, SecondLevelCache::Mixin)
+    ActiveRecord::Base.send(:include, SecondLevelCache::ActiveRecord::Base)
+    ActiveRecord::Base.send(:extend, SecondLevelCache::ActiveRecord::FetchByUniqKey)
 
-ActiveRecord::Base.send(:include, SecondLevelCache::ActiveRecord::Persistence)
-ActiveRecord::Associations::BelongsToAssociation.send(:include, SecondLevelCache::ActiveRecord::Associations::BelongsToAssociation)
-ActiveRecord::Associations::HasOneAssociation.send(:include, SecondLevelCache::ActiveRecord::Associations::HasOneAssociation)
-ActiveRecord::Associations::Preloader::BelongsTo.send(:include, SecondLevelCache::ActiveRecord::Associations::Preloader::BelongsTo)
+    ActiveRecord::Base.send(:include, SecondLevelCache::ActiveRecord::Persistence)
+    ActiveRecord::Associations::BelongsToAssociation.send(:include, SecondLevelCache::ActiveRecord::Associations::BelongsToAssociation)
+    ActiveRecord::Associations::HasOneAssociation.send(:include, SecondLevelCache::ActiveRecord::Associations::HasOneAssociation)
+    ActiveRecord::Associations::Preloader::BelongsTo.send(:include, SecondLevelCache::ActiveRecord::Associations::Preloader::BelongsTo)
+  end
+end


### PR DESCRIPTION
When I use second_level_cache in Rails 4.2, I often see this message:

```
DEPRECATION WARNING: Currently, Active Record suppresses errors raised within `after_rollback`/`after_commit` callbacks and only print them to the logs. In the next version, these errors will no longer be suppressed. Instead, the errors will propagate normally just like in other Active Record callbacks.

You can opt into the new behavior and remove this warning by setting:

  config.active_record.raise_in_transactional_callbacks = true
```

This is because after_commit gets called before Rails.config is run. I think it is good to extend AR::Base using Railtie to avoid this issue.

I don't know how to run your test, so can you see if this works or not? Cheers