### PR TITLE
Fix has_one with a conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # SecondLevelCache
 
-[![Gem Version](https://badge.fury.io/rb/second_level_cache.png)](http://badge.fury.io/rb/second_level_cache)
-[![Dependency Status](https://gemnasium.com/hooopo/second_level_cache.png)](https://gemnasium.com/hooopo/second_level_cache)
-[![Build Status](https://travis-ci.org/hooopo/second_level_cache.png?branch=master)](https://travis-ci.org/hooopo/second_level_cache)
-[![Code Climate](https://codeclimate.com/github/hooopo/second_level_cache.png)](https://codeclimate.com/github/hooopo/second_level_cache)
+[![Gem Version](https://badge.fury.io/rb/second_level_cache.svg)](http://badge.fury.io/rb/second_level_cache)
+[![Dependency Status](https://gemnasium.com/hooopo/second_level_cache.svg)](https://gemnasium.com/hooopo/second_level_cache)
+[![Build Status](https://travis-ci.org/hooopo/second_level_cache.svg?branch=master)](https://travis-ci.org/hooopo/second_level_cache)
+[![Code Climate](https://codeclimate.com/github/hooopo/second_level_cache.svg)](https://codeclimate.com/github/hooopo/second_level_cache)
 
 SecondLevelCache is a write-through and read-through caching library inspired by Cache Money and cache_fu, support ActiveRecord 4.
 
@@ -91,13 +91,13 @@ ActiveRecord::Base.transaction do
    user.save
    account.save
    Rails.logger.info "info"
-end # <- Cache write 
+end # <- Cache write
 
 # if you want to do something after user and account's write_second_level_cache operation, do this way:
 ActiveRecord::Base.transaction do
    user.save
    account.save
-end # <- Cache write 
+end # <- Cache write
 Rails.logger.info "info"
 ```
 
@@ -114,7 +114,7 @@ In production env, we recommend to use [Dalli](https://github.com/mperham/dalli)
  config.cache_store = [:dalli_store, APP_CONFIG["memcached_host"], {:namespace => "ns", :compress => true}]
 ```
 
-## Tips: 
+## Tips:
 
 * When you want to clear only second level cache apart from other cache for example fragment cache in cache store,
 you can only change the `cache_key_prefix`:
@@ -130,7 +130,7 @@ class User < ActiveRecord::Base
 end
 ```
 
-* It provides a great feature, not hits db when fetching record via unique key(not primary key). 
+* It provides a great feature, not hits db when fetching record via unique key(not primary key).
 
 ```ruby
 # this will fetch from cache

--- a/lib/second_level_cache/active_record/has_one_association.rb
+++ b/lib/second_level_cache/active_record/has_one_association.rb
@@ -12,8 +12,8 @@ module SecondLevelCache
 
         def find_target_with_second_level_cache
           return find_target_without_second_level_cache unless klass.second_level_cache_enabled?
-          return find_target_without_second_level_cache if reflection.options[:through]
-          # TODO: implement cache with has_one through
+          return find_target_without_second_level_cache if reflection.options[:through] || reflection.scope
+          # TODO: implement cache with has_one through, scope
           if reflection.options[:as]
             cache_record = klass.fetch_by_uniq_keys({reflection.foreign_key => owner[reflection.active_record_primary_key], reflection.type => owner.class.base_class.name})
           else

--- a/test/has_one_association_test.rb
+++ b/test/has_one_association_test.rb
@@ -24,4 +24,14 @@ class HasOneAssociationTest < ActiveSupport::TestCase
     #   clean_user.forked_from_user
     # end
   end
+
+  def test_has_one_with_conditions
+    user = User.create name: 'hooopo', email: 'hoooopo@gmail.com'
+    group_namespace1 = Namespace.create(user_id: user.id, name: 'ruby-china', kind: 'group')
+    user.create_namespace(name: 'hooopo')
+    group_namespace2 = Namespace.create(user_id: user.id, name: 'rails', kind: 'group')
+    assert_not_equal user.namespace, nil
+    clear_user = User.find(user.id)
+    assert_equal clear_user.namespace.name, 'hooopo'
+  end
 end

--- a/test/model/user.rb
+++ b/test/model/user.rb
@@ -15,6 +15,13 @@ ActiveRecord::Base.connection.create_table(:forked_user_links, :force => true) d
   t.timestamps null: false
 end
 
+ActiveRecord::Base.connection.create_table(:namespaces, :force => true) do |t|
+  t.integer :user_id
+  t.string  :kind
+  t.string  :name
+  t.timestamps null: false
+end
+
 class User < ActiveRecord::Base
   CacheVersion = 3
   serialize :options, Array
@@ -25,8 +32,16 @@ class User < ActiveRecord::Base
   has_one  :account
   has_one  :forked_user_link, foreign_key: 'forked_to_user_id'
   has_one  :forked_from_user, through: :forked_user_link
+  has_many :namespaces
+  has_one  :namespace, -> { where(kind: nil) }
   has_many :books
   has_many :images, :as => :imagable
+end
+
+class Namespace < ActiveRecord::Base
+  acts_as_cached(:version => 1, :expires_in => 3.day)
+
+  belongs_to :user
 end
 
 class ForkedUserLink < ActiveRecord::Base


### PR DESCRIPTION
在 GitLab 的场景里面发现的，如果 has_one 带有条件，将会命中到错误的 cache 而导致数据不正确，原因是 fetch_by_uniq_keys 没有带 `reflection.scope` 条件，由于 reflection.scope 是 Proc 类型，不好用于 cache_key，所以这里遇到此类场景，就不走 cache 了，避免有错