### PR TITLE
Fix for Rails 5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.2.0
+-----
+
+* ActiveRecord 5 ready! Do not support ActiveRecord 4 and lower versions now (use second_level_cache 2.1.x).
+* Requirement Ruby 2.3+.
+
 2.0.0.rc1
 -----
 * ActiveRecord 4 ready!

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rails', '~> 4.1'
+gem 'rails', '~> 5.0.0.beta2'

--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -23,8 +23,8 @@ module SecondLevelCache
         @second_level_cache_options = options
         @second_level_cache_options[:expires_in] ||= 1.week
         @second_level_cache_options[:version] ||= 0
-        relation.class.send :include, SecondLevelCache::ActiveRecord::FinderMethods
-        include SecondLevelCache::ActiveRecord::Core if /^4\.2\./.match(::ActiveRecord.version.version)
+        relation.class.send :prepend, SecondLevelCache::ActiveRecord::FinderMethods
+        prepend SecondLevelCache::ActiveRecord::Core
       end
 
       def second_level_cache_enabled?

--- a/lib/second_level_cache/active_record.rb
+++ b/lib/second_level_cache/active_record.rb
@@ -12,11 +12,11 @@ if defined? Rails
   require 'second_level_cache/active_record/railtie'
 else
   ActiveRecord::Base.send(:include, SecondLevelCache::Mixin)
-  ActiveRecord::Base.send(:include, SecondLevelCache::ActiveRecord::Base)
+  ActiveRecord::Base.send(:prepend, SecondLevelCache::ActiveRecord::Base)
   ActiveRecord::Base.send(:extend, SecondLevelCache::ActiveRecord::FetchByUniqKey)
 
-  ActiveRecord::Base.send(:include, SecondLevelCache::ActiveRecord::Persistence)
-  ActiveRecord::Associations::BelongsToAssociation.send(:include, SecondLevelCache::ActiveRecord::Associations::BelongsToAssociation)
-  ActiveRecord::Associations::HasOneAssociation.send(:include, SecondLevelCache::ActiveRecord::Associations::HasOneAssociation)
-  ActiveRecord::Associations::Preloader::BelongsTo.send(:include, SecondLevelCache::ActiveRecord::Associations::Preloader::BelongsTo)
+  ActiveRecord::Base.send(:prepend, SecondLevelCache::ActiveRecord::Persistence)
+  ActiveRecord::Associations::BelongsToAssociation.send(:prepend, SecondLevelCache::ActiveRecord::Associations::BelongsToAssociation)
+  ActiveRecord::Associations::HasOneAssociation.send(:prepend, SecondLevelCache::ActiveRecord::Associations::HasOneAssociation)
+  ActiveRecord::Associations::Preloader::BelongsTo.send(:prepend, SecondLevelCache::ActiveRecord::Associations::Preloader::BelongsTo)
 end

--- a/lib/second_level_cache/active_record/base.rb
+++ b/lib/second_level_cache/active_record/base.rb
@@ -8,16 +8,17 @@ module SecondLevelCache
         after_commit :expire_second_level_cache, :on => :destroy
         after_commit :update_second_level_cache, :on => :update
         after_commit :write_second_level_cache, :on => :create
+      end
 
-        class << self
-          alias_method_chain :update_counters, :cache
+      def self.prepended(base)
+        class << base
+          prepend ClassMethods
         end
-
       end
 
       module ClassMethods
-        def update_counters_with_cache(id, counters)
-          update_counters_without_cache(id, counters).tap do
+        def update_counters(id, counters)
+          super(id, counters).tap do
             Array(id).each{|i| expire_second_level_cache(i)}
           end
         end

--- a/lib/second_level_cache/active_record/base.rb
+++ b/lib/second_level_cache/active_record/base.rb
@@ -2,15 +2,11 @@
 module SecondLevelCache
   module ActiveRecord
     module Base
-      extend ActiveSupport::Concern
-
-      included do
-        after_commit :expire_second_level_cache, :on => :destroy
-        after_commit :update_second_level_cache, :on => :update
-        after_commit :write_second_level_cache, :on => :create
-      end
-
       def self.prepended(base)
+        base.after_commit :expire_second_level_cache, on: :destroy
+        base.after_commit :update_second_level_cache, on: :update
+        base.after_commit :write_second_level_cache, on: :create
+
         class << base
           prepend ClassMethods
         end
@@ -19,7 +15,7 @@ module SecondLevelCache
       module ClassMethods
         def update_counters(id, counters)
           super(id, counters).tap do
-            Array(id).each{|i| expire_second_level_cache(i)}
+            Array(id).each{ |i| expire_second_level_cache(i) }
           end
         end
       end

--- a/lib/second_level_cache/active_record/belongs_to_association.rb
+++ b/lib/second_level_cache/active_record/belongs_to_association.rb
@@ -3,15 +3,10 @@ module SecondLevelCache
   module ActiveRecord
     module Associations
       module BelongsToAssociation
-        extend ActiveSupport::Concern
-
-        included do
-        end
-
         def find_target
           return super unless klass.second_level_cache_enabled?
           cache_record = klass.read_second_level_cache(second_level_cache_key)
-          return cache_record.tap{|record| set_inverse_instance(record)} if cache_record
+          return cache_record.tap { |record| set_inverse_instance(record) } if cache_record
           record = super
 
           record.tap do |r|

--- a/lib/second_level_cache/active_record/belongs_to_association.rb
+++ b/lib/second_level_cache/active_record/belongs_to_association.rb
@@ -4,17 +4,15 @@ module SecondLevelCache
     module Associations
       module BelongsToAssociation
         extend ActiveSupport::Concern
+
         included do
-          class_eval do
-            alias_method_chain :find_target, :second_level_cache
-          end
         end
 
-        def find_target_with_second_level_cache
-          return find_target_without_second_level_cache unless klass.second_level_cache_enabled?
+        def find_target
+          return super unless klass.second_level_cache_enabled?
           cache_record = klass.read_second_level_cache(second_level_cache_key)
           return cache_record.tap{|record| set_inverse_instance(record)} if cache_record
-          record = find_target_without_second_level_cache
+          record = super
 
           record.tap do |r|
             set_inverse_instance(r)

--- a/lib/second_level_cache/active_record/core.rb
+++ b/lib/second_level_cache/active_record/core.rb
@@ -2,8 +2,6 @@
 module SecondLevelCache
   module ActiveRecord
     module Core
-      extend ActiveSupport::Concern
-
       def self.prepended(base)
         class << base
           prepend ClassMethods

--- a/lib/second_level_cache/active_record/core.rb
+++ b/lib/second_level_cache/active_record/core.rb
@@ -4,17 +4,16 @@ module SecondLevelCache
     module Core
       extend ActiveSupport::Concern
 
-      included do
-        class << self
-          alias_method_chain :find, :cache
+      def self.prepended(base)
+        class << base
+          prepend ClassMethods
         end
-
       end
 
       module ClassMethods
-        def find_with_cache(*ids)
+        def find(*ids)
           return all.find(ids.first) if ids.size == 1 && ids.first.is_a?(Fixnum)
-          find_without_cache(*ids)
+          super(*ids)
         end
       end
     end

--- a/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
+++ b/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
@@ -8,14 +8,14 @@ module SecondLevelCache
           self.find(_id) rescue nil
         else
           record = self.where(where_values).first
-          record.tap{|record| SecondLevelCache.cache_store.write(cache_key, record.id)} if record
+          record.tap { |record| SecondLevelCache.cache_store.write(cache_key, record.id) } if record
         end
       end
-      
+
       def fetch_by_uniq_keys!(where_values)
         fetch_by_uniq_keys(where_values) || raise(::ActiveRecord::RecordNotFound)
       end
-      
+
       def fetch_by_uniq_key(value, uniq_key_name)
         # puts "[Deprecated] will remove in the future, use fetch_by_uniq_keys method instead."
         fetch_by_uniq_keys(uniq_key_name => value)
@@ -27,12 +27,13 @@ module SecondLevelCache
       end
 
       private
-      
+
       def cache_uniq_key(where_values)
-        ext_key = where_values.collect { |k,v|
+        keys = where_values.collect do |k,v|
           v = Digest::MD5.hexdigest(v) if v && v.size >= 32
           [k,v].join("_")
-        }.join(",")
+        end
+        ext_key = keys.join(",")
         "uniq_key_#{self.name}_#{ext_key}"
       end
     end

--- a/lib/second_level_cache/active_record/finder_methods.rb
+++ b/lib/second_level_cache/active_record/finder_methods.rb
@@ -36,10 +36,14 @@ module SecondLevelCache
     private
 
       def cachable?
-        limit_one? && order_values.blank? &&
-          includes_values.blank? && preload_values.blank? &&
-          readonly_value.nil? && joins_values.blank? && !@klass.locking_enabled? &&
-          where_clause_match_equality?
+        limit_one? &&
+        order_values.blank? &&
+        includes_values.blank? &&
+        preload_values.blank? &&
+        readonly_value.nil? &&
+        joins_values.blank? &&
+        !@klass.locking_enabled? &&
+        where_clause_match_equality?
       end
 
       def where_clause_match_equality?

--- a/lib/second_level_cache/active_record/has_one_association.rb
+++ b/lib/second_level_cache/active_record/has_one_association.rb
@@ -10,11 +10,15 @@ module SecondLevelCache
           return super if reflection.options[:through] || reflection.scope
           # TODO: implement cache with has_one through, scope
           if reflection.options[:as]
-            cache_record = klass.fetch_by_uniq_keys({reflection.foreign_key => owner[reflection.active_record_primary_key], reflection.type => owner.class.base_class.name})
+            keys = {
+              reflection.foreign_key => owner[reflection.active_record_primary_key],
+              reflection.type => owner.class.base_class.name
+            }
+            cache_record = klass.fetch_by_uniq_keys(keys)
           else
             cache_record = klass.fetch_by_uniq_key(owner[reflection.active_record_primary_key], reflection.foreign_key)
           end
-          return cache_record.tap{|record| set_inverse_instance(record)} if cache_record
+          return cache_record.tap { |record| set_inverse_instance(record) } if cache_record
 
           record = super
 

--- a/lib/second_level_cache/active_record/has_one_association.rb
+++ b/lib/second_level_cache/active_record/has_one_association.rb
@@ -3,8 +3,6 @@ module SecondLevelCache
   module ActiveRecord
     module Associations
       module HasOneAssociation
-        extend ActiveSupport::Concern
-
         def find_target
           return super unless klass.second_level_cache_enabled?
           return super if reflection.options[:through] || reflection.scope

--- a/lib/second_level_cache/active_record/has_one_association.rb
+++ b/lib/second_level_cache/active_record/has_one_association.rb
@@ -4,15 +4,10 @@ module SecondLevelCache
     module Associations
       module HasOneAssociation
         extend ActiveSupport::Concern
-        included do
-          class_eval do
-            alias_method_chain :find_target, :second_level_cache
-          end
-        end
 
-        def find_target_with_second_level_cache
-          return find_target_without_second_level_cache unless klass.second_level_cache_enabled?
-          return find_target_without_second_level_cache if reflection.options[:through] || reflection.scope
+        def find_target
+          return super unless klass.second_level_cache_enabled?
+          return super if reflection.options[:through] || reflection.scope
           # TODO: implement cache with has_one through, scope
           if reflection.options[:as]
             cache_record = klass.fetch_by_uniq_keys({reflection.foreign_key => owner[reflection.active_record_primary_key], reflection.type => owner.class.base_class.name})
@@ -21,7 +16,7 @@ module SecondLevelCache
           end
           return cache_record.tap{|record| set_inverse_instance(record)} if cache_record
 
-          record = find_target_without_second_level_cache
+          record = super
 
           record.tap do |r|
             set_inverse_instance(r)

--- a/lib/second_level_cache/active_record/persistence.rb
+++ b/lib/second_level_cache/active_record/persistence.rb
@@ -4,25 +4,17 @@ module SecondLevelCache
     module Persistence
       extend ActiveSupport::Concern
 
-      included do
-        class_eval do
-          alias_method_chain :reload, :second_level_cache
-          alias_method_chain :touch, :second_level_cache
-          alias_method_chain :update_column, :second_level_cache
-        end
+      def update_column(name, value)
+        super(name, value).tap{update_second_level_cache}
       end
 
-      def update_column_with_second_level_cache(name, value)
-        update_column_without_second_level_cache(name, value).tap{update_second_level_cache}
-      end
-
-      def reload_with_second_level_cache(options = nil)
+      def reload(options = nil)
         expire_second_level_cache
-        reload_without_second_level_cache(options)
+        super(options)
       end
 
-      def touch_with_second_level_cache(*names)
-        touch_without_second_level_cache(*names).tap{update_second_level_cache}
+      def touch(*names)
+        super(*names).tap{update_second_level_cache}
       end
     end
   end

--- a/lib/second_level_cache/active_record/persistence.rb
+++ b/lib/second_level_cache/active_record/persistence.rb
@@ -2,10 +2,8 @@
 module SecondLevelCache
   module ActiveRecord
     module Persistence
-      extend ActiveSupport::Concern
-
       def update_column(name, value)
-        super(name, value).tap{update_second_level_cache}
+        super(name, value).tap { update_second_level_cache }
       end
 
       def reload(options = nil)
@@ -14,7 +12,7 @@ module SecondLevelCache
       end
 
       def touch(*names)
-        super(*names).tap{update_second_level_cache}
+        super(*names).tap { update_second_level_cache }
       end
     end
   end

--- a/lib/second_level_cache/active_record/preloader.rb
+++ b/lib/second_level_cache/active_record/preloader.rb
@@ -4,8 +4,6 @@ module SecondLevelCache
     module Associations
       class Preloader
         module BelongsTo
-          extend ActiveSupport::Concern
-
           def records_for(ids)
             return super(ids) unless klass.second_level_cache_enabled?
 

--- a/lib/second_level_cache/active_record/preloader.rb
+++ b/lib/second_level_cache/active_record/preloader.rb
@@ -6,16 +6,16 @@ module SecondLevelCache
         module BelongsTo
           extend ActiveSupport::Concern
 
-          def records(ids)
+          def records_for(ids)
             return super(ids) unless klass.second_level_cache_enabled?
 
-            map_cache_keys = ids.map{|id| klass.second_level_cache_key(id)}
+            map_cache_keys = ids.map { |id| klass.second_level_cache_key(id) }
             records_from_cache = ::SecondLevelCache.cache_store.read_multi(*map_cache_keys)
             # NOTICE
             # Rails.cache.read_multi return hash that has keys only hitted.
             # eg. Rails.cache.read_multi(1,2,3) => {2 => hit_value, 3 => hit_value}
-            hitted_ids = records_from_cache.map{|key, _| key.split("/")[2].to_i}
-            missed_ids = ids.map{|x| x.to_i} - hitted_ids
+            hitted_ids = records_from_cache.map { |key, _| key.split("/")[2].to_i }
+            missed_ids = ids.map { |x| x.to_i } - hitted_ids
 
             ::SecondLevelCache::Config.logger.info "missed ids -> #{missed_ids.inspect} | hitted ids -> #{hitted_ids.inspect}"
 
@@ -23,7 +23,7 @@ module SecondLevelCache
               RecordMarshal.load_multi(records_from_cache.values)
             else
               records_from_db = super(missed_ids)
-              records_from_db.map{|record| write_cache(record); record} + RecordMarshal.load_multi(records_from_cache.values)
+              records_from_db.map { |record| write_cache(record); record } + RecordMarshal.load_multi(records_from_cache.values)
             end
           end
 

--- a/lib/second_level_cache/active_record/railtie.rb
+++ b/lib/second_level_cache/active_record/railtie.rb
@@ -1,12 +1,12 @@
 class SecondLevelCache::ActiveRecord::Railtie < Rails::Railtie
   initializer "second_level_cache.active_record.initialization" do
     ActiveRecord::Base.send(:include, SecondLevelCache::Mixin)
-    ActiveRecord::Base.send(:include, SecondLevelCache::ActiveRecord::Base)
+    ActiveRecord::Base.send(:prepend, SecondLevelCache::ActiveRecord::Base)
     ActiveRecord::Base.send(:extend, SecondLevelCache::ActiveRecord::FetchByUniqKey)
 
-    ActiveRecord::Base.send(:include, SecondLevelCache::ActiveRecord::Persistence)
-    ActiveRecord::Associations::BelongsToAssociation.send(:include, SecondLevelCache::ActiveRecord::Associations::BelongsToAssociation)
-    ActiveRecord::Associations::HasOneAssociation.send(:include, SecondLevelCache::ActiveRecord::Associations::HasOneAssociation)
-    ActiveRecord::Associations::Preloader::BelongsTo.send(:include, SecondLevelCache::ActiveRecord::Associations::Preloader::BelongsTo)
+    ActiveRecord::Base.send(:prepend, SecondLevelCache::ActiveRecord::Persistence)
+    ActiveRecord::Associations::BelongsToAssociation.send(:prepend, SecondLevelCache::ActiveRecord::Associations::BelongsToAssociation)
+    ActiveRecord::Associations::HasOneAssociation.send(:prepend, SecondLevelCache::ActiveRecord::Associations::HasOneAssociation)
+    ActiveRecord::Associations::Preloader::BelongsTo.send(:prepend, SecondLevelCache::ActiveRecord::Associations::Preloader::BelongsTo)
   end
 end

--- a/lib/second_level_cache/record_marshal.rb
+++ b/lib/second_level_cache/record_marshal.rb
@@ -24,33 +24,21 @@ module RecordMarshal
       #fix 2.1.4 object.changed? is true
       #fix Rails 4.2 is deprecating `serialized_attributes` without replacement to Rails 5 is deprecating `serialized_attributes` without replacement
       klass, attributes = serialized[0].constantize, serialized[1]
-      if ::ActiveRecord::VERSION::STRING < '4.2.0'
-        klass.serialized_attributes.each do |k, v|
-          next if attributes[k].nil? || attributes[k].is_a?(String)
-          if attributes[k].respond_to?(:unserialize)
-            if attributes[k].serialized_value.is_a?(String)
-              attributes[k] = attributes[k].serialized_value
-              next
-            end
 
-            if ::ActiveRecord::VERSION::STRING >= '4.1.0' && attributes[k].coder == ActiveRecord::Coders::JSON
-              attributes[k] = attributes[k].serialized_value.to_json
-            else
-              attributes[k] = attributes[k].serialized_value
-            end
-          end
-        end
-      else
-        klass.columns.select{|t| t.cast_type.is_a?(::ActiveRecord::Type::Serialized) }.each do |c|
-          name, coder = c.name, c.cast_type.coder
-          next if attributes[name].nil? || attributes[name].is_a?(String)
-          if coder.is_a?(ActiveRecord::Coders::YAMLColumn)
-            attributes[name] = coder.dump(attributes[name]) if attributes[name].is_a?(coder.object_class)
-          elsif coder == ActiveRecord::Coders::JSON
-            attributes[name] = attributes[name].to_json
-          end
+      # for ActiveRecord 5.0.0
+      klass.columns.each do |c|
+        name = c.name
+        cast_type = klass.attribute_types[name]
+        next if !cast_type.is_a?(::ActiveRecord::Type::Serialized)
+        coder = cast_type.coder
+        next if attributes[name].nil? || attributes[name].is_a?(String)
+        if coder.is_a?(::ActiveRecord::Coders::YAMLColumn)
+          attributes[name] = coder.dump(attributes[name]) if attributes[name].is_a?(coder.object_class)
+        elsif coder == ::ActiveRecord::Coders::JSON
+          attributes[name] = attributes[name].to_json
         end
       end
+
       klass.instantiate(attributes)
     end
 

--- a/lib/second_level_cache/version.rb
+++ b/lib/second_level_cache/version.rb
@@ -1,4 +1,4 @@
 # -*- encoding : utf-8 -*-
-module SecondLevelCache 
-  VERSION = "2.1.9"
+module SecondLevelCache
+  VERSION = "2.2.0"
 end

--- a/second_level_cache.gemspec
+++ b/second_level_cache.gemspec
@@ -30,9 +30,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = SecondLevelCache::VERSION
 
-  gem.add_runtime_dependency "activesupport", ["> 4.0.0", "< 5.0"]
+  gem.add_runtime_dependency "activesupport", [">= 5.0.0.beta1", "< 5.1.0"]
+  gem.add_runtime_dependency "activerecord", [">= 5.0.0.beta1", "< 5.1.0"]
 
-  gem.add_runtime_dependency "activerecord", ["> 4.0.0", "< 5.0"]
   gem.add_development_dependency "sqlite3"
   gem.add_development_dependency "rake"
   gem.add_development_dependency 'pry'

--- a/test/belongs_to_association_test.rb
+++ b/test/belongs_to_association_test.rb
@@ -10,7 +10,7 @@ class BelongsToAssociationTest < ActiveSupport::TestCase
     book = @user.books.create
 
     @user.write_second_level_cache
-    book.clear_association_cache
+    book.send(:clear_association_cache)
     assert_no_queries do
       assert_equal @user, book.user
     end

--- a/test/fetch_by_uniq_key_test.rb
+++ b/test/fetch_by_uniq_key_test.rb
@@ -18,7 +18,7 @@ class FetchByUinqKeyTest < ActiveSupport::TestCase
   def test_should_query_from_db_using_primary_key
     Post.fetch_by_uniq_keys(:topic_id => 2, :slug => "foobar")
     @post.expire_second_level_cache
-    assert_sql(/SELECT\s+"posts".* FROM "posts"\s+WHERE "posts"."id" = \? LIMIT 1/) do
+    assert_sql(/SELECT\s+"posts".* FROM "posts"\s+WHERE "posts"."id" = \? LIMIT ?/) do
       Post.fetch_by_uniq_keys(:topic_id => 2, :slug => "foobar")
     end
   end

--- a/test/preloader_test.rb
+++ b/test/preloader_test.rb
@@ -29,7 +29,7 @@ class PreloaderTest < ActiveSupport::TestCase
 
     results = nil
     assert_queries(2) do
-      assert_sql(/IN\s+\(#{expired_topic.id}\)/m) do
+      assert_sql(/WHERE\s\"topics\"\.\"id\"\s=\s#{expired_topic.id}/m) do
         results = Post.includes(:topic).order('id ASC').to_a
       end
     end

--- a/test/record_marshal_test.rb
+++ b/test/record_marshal_test.rb
@@ -48,6 +48,6 @@ class RecordMarshalTest < ActiveSupport::TestCase
   def test_should_load_active_record_object_without_association_cache
     @user.books
     @user.write_second_level_cache
-    assert_empty User.read_second_level_cache(@user.id).association_cache
+    assert_empty User.read_second_level_cache(@user.id).association_cached?('id')
   end
 end

--- a/test/record_marshal_test.rb
+++ b/test/record_marshal_test.rb
@@ -48,6 +48,6 @@ class RecordMarshalTest < ActiveSupport::TestCase
   def test_should_load_active_record_object_without_association_cache
     @user.books
     @user.write_second_level_cache
-    assert_empty User.read_second_level_cache(@user.id).association_cached?('id')
+    assert_equal false, User.read_second_level_cache(@user.id).association_cached?('id')
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,6 @@ require 'active_record_test_case_helper'
 require 'database_cleaner'
 require 'active_record'
 
-ActiveRecord::Base.raise_in_transactional_callbacks = true if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks=)
 ActiveSupport.test_order = :sorted if ActiveSupport.respond_to?(:test_order=)
 
 require 'second_level_cache'


### PR DESCRIPTION
- 去掉了 Rails 4.x 的支持，我建议以后 4.x 的基于 second_level_cache 来改动；
- 修正 ActiveRecord 5 下面的支持;
- 用 Module#prepend 来代替 `alias_method_chain`;
- Version 2.2.0