### PR TITLE
Add where(id: n).first hit cache support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 2.2.2
 -----
 
-* Add `where(id: n).first`, `where(id: n).last` hit cache support.
+* Add `where(id: n).first`, `where(id: n).last` hit cache support. This improve will avoid some gems query database, for example: [devise](https://github.com/plataformatec/devise) `current_user` method.
 
 2.2.1
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2.2.2
+-----
+
+* Add `where(id: n).first`, `where(id: n).last` hit cache support.
+
 2.2.1
 -----
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Then it will fetch cached object in this situations:
 User.find(1)
 user.articles.find(1)
 User.where(status: 1).find(1)
+User.where(id: 1).first # or .last
 article.user
 ```
 

--- a/gemfiles/Gemfile-5-0
+++ b/gemfiles/Gemfile-5-0
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'rails', :github => 'rails/rails', :ref => '6ece7df8d80c6d93db43878fa4c0278a0204072c'
+gem 'rails', '5.0.0.beta3'

--- a/lib/second_level_cache/version.rb
+++ b/lib/second_level_cache/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module SecondLevelCache
-  VERSION = '2.2.1'.freeze
+  VERSION = '2.2.2'.freeze
 end

--- a/test/finder_methods_test.rb
+++ b/test/finder_methods_test.rb
@@ -40,4 +40,18 @@ class FinderMethodsTest < ActiveSupport::TestCase
     end
     refute_equal @user.name, @from_db.name
   end
+
+  def test_where_and_first_should_with_cache
+    @user.write_second_level_cache
+    assert_no_queries do
+      assert_equal @user, User.where(id: @user.id).first
+    end
+  end
+
+  def test_where_and_last_should_with_cache
+    @user.write_second_level_cache
+    assert_no_queries do
+      assert_equal @user, User.where(id: @user.id).last
+    end
+  end
 end


### PR DESCRIPTION
## 为何有这个？

因为 Devise controller `current_user` 方法调用了 [orm_adapter.get](https://github.com/ianwhite/orm_adapter/blob/master/lib/orm_adapter/adapters/active_record.rb#L17)  方法，然后不知道为何里面的实现是这样的：

```rb
def get(id)
  klass.where(klass.primary_key => wrap_key(id)).first
end
```

所以，如果我们实现掉这个，所有同时用 Devise 和 second_level_cache 的用户都能避免 current_user 的调用查询数据库。