### PR TITLE
FIX #42

### DIFF
--- a/lib/second_level_cache/record_marshal.rb
+++ b/lib/second_level_cache/record_marshal.rb
@@ -37,7 +37,7 @@ module RecordMarshal
       end
 
       klass.defined_enums.each do |key, value|
-        attributes[key] = value[attributes[key]]
+        attributes[key] = value[attributes[key]] if attributes[key].is_a?(String)
       end
 
       klass.instantiate(attributes)

--- a/test/record_marshal_test.rb
+++ b/test/record_marshal_test.rb
@@ -3,11 +3,12 @@ require 'test_helper'
 class RecordMarshalTest < ActiveSupport::TestCase
   def setup
     if ::ActiveRecord::VERSION::STRING >= '4.1.0'
-      @json_options = { 'name' => 'Test', 'age' => 18 }
+      @json_options = { 'name' => 'Test', 'age' => 18, 'hash' => {'name' => 'dup'} }
       @user = User.create name: 'csdn',
                           email: 'test@csdn.com',
                           options: [1, 2],
-                          json_options: @json_options
+                          json_options: @json_options,
+                          status: :active
     else
       @user = User.create name: 'csdn',
                           email: 'test@csdn.com',
@@ -46,5 +47,12 @@ class RecordMarshalTest < ActiveSupport::TestCase
     @user.books
     @user.write_second_level_cache
     assert_equal false, User.read_second_level_cache(@user.id).association_cached?('id')
+  end
+
+  def test_should_thread_safe_load
+    user = User.find @user.id
+    assert_equal 'active', user.status
+    user = User.find @user.id
+    assert_equal 'active', user.status
   end
 end

--- a/test/record_marshal_test.rb
+++ b/test/record_marshal_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class RecordMarshalTest < ActiveSupport::TestCase
   def setup
     if ::ActiveRecord::VERSION::STRING >= '4.1.0'
-      @json_options = { 'name' => 'Test', 'age' => 18, 'hash' => {'name' => 'dup'} }
+      @json_options = { 'name' => 'Test', 'age' => 18, 'hash' => { 'name' => 'dup' } }
       @user = User.create name: 'csdn',
                           email: 'test@csdn.com',
                           options: [1, 2],


### PR DESCRIPTION
在同一请求或同一个线程中Rails.cache.read 'xxx'返回的是同一份数据并不是拷贝,所以我们在中间如果对其有任合修改会影响同线程的下次请求。
```ruby
      klass.defined_enums.each do |key, value|
        attributes[key] = value[attributes[key]]
      end
```
以上代码如果在同一线程第一次请求返回的Cache Object是没有问题，但我们把attributes中的enum字段的值由key改为value,所以下次请求的时候就会现value[attributes[key]] = nil 也最终导至Cache Object的所有enum字段都为空。

感觉最安全的方式还是拷贝一份再来修改会好一些。