### PR TITLE
修 ActiveRecord 5.0.1 API 变化带出来的错误

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.3.0
 gemfile:
   - gemfiles/Gemfile-5-0
+  - gemfiles/Gemfile-5-0-1
   - gemfiles/Gemfile-edge
 matrix:
   allow_failures:

--- a/gemfiles/Gemfile-5-0
+++ b/gemfiles/Gemfile-5-0
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'rails', '5.0.0'
+gem 'rails', '5.0.1'

--- a/gemfiles/Gemfile-5-0-1
+++ b/gemfiles/Gemfile-5-0-1
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'rails', '5.0.0'
+gem 'rails', '5.0.1'

--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -1,6 +1,7 @@
 require 'active_support/all'
 require 'second_level_cache/config'
 require 'second_level_cache/record_marshal'
+require 'second_level_cache/record_relation'
 
 module SecondLevelCache
   def self.configure

--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -29,6 +29,7 @@ module SecondLevelCache
       end
 
       def second_level_cache_enabled?
+        return false if !defined? @second_level_cache_enabled
         @second_level_cache_enabled == true
       end
 

--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -30,8 +30,11 @@ module SecondLevelCache
       end
 
       def second_level_cache_enabled?
-        return false if !defined? @second_level_cache_enabled
-        @second_level_cache_enabled == true
+        if defined? @second_level_cache_enabled
+          @second_level_cache_enabled == true
+        else
+          false
+        end
       end
 
       def without_second_level_cache

--- a/lib/second_level_cache/active_record/preloader.rb
+++ b/lib/second_level_cache/active_record/preloader.rb
@@ -19,7 +19,7 @@ module SecondLevelCache
             record_marshals = RecordMarshal.load_multi(records_from_cache.values)
 
             if missed_ids.empty?
-              return record_marshals
+              return SecondLevelCache::RecordRelation.new(record_marshals)
             end
 
             records_from_db = super(missed_ids)
@@ -27,7 +27,7 @@ module SecondLevelCache
               write_cache(r)
             end
 
-            records_from_db + record_marshals
+            SecondLevelCache::RecordRelation.new(records_from_db + record_marshals)
           end
 
           private

--- a/lib/second_level_cache/record_relation.rb
+++ b/lib/second_level_cache/record_relation.rb
@@ -1,13 +1,15 @@
 module SecondLevelCache
   class RecordRelation < Array
-    # A fake Array for fix Rails 5.0.1 records_for method changed bug
-    # in Rails 5.0.0 called:
-    #   records_for()
+    # A fake Array for fix ActiveRecord 5.0.1 records_for method changed bug
+    #
+    # in ActiveRecord 5.0.0 called:
+    #   records_for(slice)
     #
     # but 5.0.1 called:
-    #   records_for().load(&block)
+    #   https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/preloader/association.rb#L118
+    #   records_for(slice).load(&block)
     #
-    # https://github.com/rails/rails/pull/26340/
+    # https://github.com/rails/rails/pull/26340
     def load(&block)
       return self
     end

--- a/lib/second_level_cache/record_relation.rb
+++ b/lib/second_level_cache/record_relation.rb
@@ -1,0 +1,15 @@
+module SecondLevelCache
+  class RecordRelation < Array
+    # A fake Array for fix Rails 5.0.1 records_for method changed bug
+    # in Rails 5.0.0 called:
+    #   records_for()
+    #
+    # but 5.0.1 called:
+    #   records_for().load(&block)
+    #
+    # https://github.com/rails/rails/pull/26340/
+    def load(&block)
+      return self
+    end
+  end
+end

--- a/lib/second_level_cache/record_relation.rb
+++ b/lib/second_level_cache/record_relation.rb
@@ -10,8 +10,8 @@ module SecondLevelCache
     #   records_for(slice).load(&block)
     #
     # https://github.com/rails/rails/pull/26340
-    def load(&block)
-      return self
+    def load(&_block)
+      self
     end
   end
 end

--- a/test/has_one_association_test.rb
+++ b/test/has_one_association_test.rb
@@ -45,6 +45,6 @@ class HasOneAssociationTest < ActiveSupport::TestCase
   def test_belongs_to_column_change
     assert_equal @user.account, @account
     @account.update(user_id: @user.id + 1)
-    assert_equal @user.reload.account, nil
+    assert_nil @user.reload.account
   end
 end


### PR DESCRIPTION
https://github.com/rails/rails/pull/26340

这个 PR 里面将 records_for 函数的调用看起来是需要 ActiveRecord::Relation 的类型了，而我们覆盖的 `records_for` 函数返回的是 Array 类型。所以造了一个假的 Array 类型，实现一个 `load(&block)` 的函数以兼容一下。


https://github.com/sgrif/rails/blob/603ebae2687a0b50fcf003cb830c57f82fb795b9/activerecord/lib/active_record/associations/preloader/association.rb#L122
```rb
def load_records(&block)
  return {} if owner_keys.empty?
  # Some databases impose a limit on the number of ids in a list (in Oracle it's 1000)
  # Make several smaller queries if necessary or make one query if the adapter supports it
  slices  = owner_keys.each_slice(klass.connection.in_clause_length || owner_keys.size)
  @preloaded_records = slices.flat_map do |slice|
    records_for(slice).load(&block)
  end
  @preloaded_records.group_by do |record|
    convert_key(record[association_key_name])
  end
end
```