### PR TITLE
Fix warning of Ruby 2.4.0

### DIFF
--- a/lib/second_level_cache/active_record/core.rb
+++ b/lib/second_level_cache/active_record/core.rb
@@ -9,7 +9,7 @@ module SecondLevelCache
 
       module ClassMethods
         def find(*ids)
-          return all.find(ids.first) if ids.size == 1 && ids.first.is_a?(Fixnum)
+          return all.find(ids.first) if ids.size == 1
           super(*ids)
         end
       end

--- a/lib/second_level_cache/config.rb
+++ b/lib/second_level_cache/config.rb
@@ -1,7 +1,7 @@
 module SecondLevelCache
   class Config
     class << self
-      attr_accessor :cache_store, :logger, :cache_key_prefix
+      attr_writer :cache_store, :logger, :cache_key_prefix
 
       def cache_store
         @cache_store ||= Rails.cache if defined?(Rails)

--- a/test/finder_methods_test.rb
+++ b/test/finder_methods_test.rb
@@ -10,6 +10,14 @@ class FinderMethodsTest < ActiveSupport::TestCase
     assert_equal @user, User.find(@user.id)
   end
 
+  def test_should_find_with_string_id
+    SecondLevelCache.cache_store.clear
+    assert_equal @user, User.find(@user.id.to_s)
+    assert_no_queries do
+      assert_equal @user, User.find(@user.id.to_s)
+    end
+  end
+
   def test_should_find_with_cache
     @user.write_second_level_cache
     assert_no_queries do


### PR DESCRIPTION
find 那个方法，看起来不需要检查类型，String 和 Integer 都是可以正常工作的。

而实际上 ActiveRecord 里面 find 的实现也是没有判断的:

https://github.com/rails/rails/blob/ba66ed094a5007e0746976781729d5d9e71b8cc9/activerecord/lib/active_record/relation/finder_methods.rb#L458