### PR TITLE
Use second_level_cache instead of acts_as_cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+2.2.7
+-----
+
+* Use `second_level_cache` instead of `acts_as_cached` method to setup in model. (#56)
+
+2.2.6
+-----
+
+* Fix warning in Ruby 2.4.0. (#54)
+
 2.2.5
 -----
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For example, cache User objects:
 
 ```ruby
 class User < ActiveRecord::Base
-  acts_as_cached(version: 1, expires_in: 1.week)
+  second_level_cache version: 1, expires_in: 1.week
 end
 ```
 
@@ -67,7 +67,9 @@ Expires cache:
 user = User.find(1)
 user.expire_second_level_cache
 ```
+
 or expires cache using class method:
+
 ```ruby
 User.expire_second_level_cache(1)
 ```
@@ -104,8 +106,8 @@ end # <- Cache write
 
 # if you want to do something after user and account's write_second_level_cache operation, do this way:
 ActiveRecord::Base.transaction do
-   user.save
-   account.save
+  user.save
+  account.save
 end # <- Cache write
 Rails.logger.info "info"
 ```
@@ -119,8 +121,9 @@ DatabaseCleaner.strategy = :truncation
 ## Configure
 
 In production env, we recommend to use [Dalli](https://github.com/mperham/dalli) as Rails cache store.
+
 ```ruby
- config.cache_store = [:dalli_store, APP_CONFIG["memcached_host"], { namespace: "ns", compress: true }]
+config.cache_store = [:dalli_store, APP_CONFIG["memcached_host"], { namespace: "ns", compress: true }]
 ```
 
 ## Tips:
@@ -131,11 +134,12 @@ you can only change the `cache_key_prefix`:
 ```ruby
 SecondLevelCache.configure.cache_key_prefix = "slc1"
 ```
+
 * When schema of your model changed, just change the `version` of the speical model, avoding clear all the cache.
 
 ```ruby
 class User < ActiveRecord::Base
-  acts_as_cached(version: 2, expires_in: 1.week)
+  second_level_cache version: 2, expires_in: 1.week
 end
 ```
 
@@ -156,6 +160,7 @@ user = User.fetch_by_uniq_keys!(nick_name: "hooopo") # this will raise `ActiveRe
 Answer.includes(:question).limit(10).order("id DESC").each{|answer| answer.question.title}
 Answer Load (0.2ms)  SELECT `answers`.* FROM `answers` ORDER BY id DESC LIMIT 10 # Only one SQL query and one Rails.cache.read_multi fetching operation.
 ```
+
 [Details for read_multi feature](http://hooopo.writings.io/articles/a9cae5e0).
 
 ## Contributors

--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -20,7 +20,7 @@ module SecondLevelCache
 
       delegate :logger, :cache_store, :cache_key_prefix, to: SecondLevelCache
 
-      def acts_as_cached(options = {})
+      def second_level_cache(options = {})
         @second_level_cache_enabled = true
         @second_level_cache_options = options
         @second_level_cache_options[:expires_in] ||= 1.week
@@ -28,6 +28,10 @@ module SecondLevelCache
         relation.class.send :prepend, SecondLevelCache::ActiveRecord::FinderMethods
         prepend SecondLevelCache::ActiveRecord::Core
       end
+
+      # TODO: remove `acts_as_cached` method in version 2.3.0
+      alias acts_as_cached second_level_cache
+      deprecate acts_as_cached: :second_level_cache, deprecator: ActiveSupport::Deprecation.new('2.3.0', 'second_level_cache')
 
       def second_level_cache_enabled?
         if defined? @second_level_cache_enabled

--- a/lib/second_level_cache/version.rb
+++ b/lib/second_level_cache/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module SecondLevelCache
-  VERSION = '2.2.6'.freeze
+  VERSION = '2.2.7'.freeze
 end

--- a/test/model/account.rb
+++ b/test/model/account.rb
@@ -6,6 +6,6 @@ ActiveRecord::Base.connection.create_table(:accounts, force: true) do |t|
 end
 
 class Account < ActiveRecord::Base
-  acts_as_cached expires_in: 3.days
+  second_level_cache expires_in: 3.days
   belongs_to :user
 end

--- a/test/model/animal.rb
+++ b/test/model/animal.rb
@@ -5,9 +5,9 @@ ActiveRecord::Base.connection.create_table(:animals, force: true) do |t|
 end
 
 class Animal < ActiveRecord::Base
-  acts_as_cached
+  second_level_cache
 end
 
 class Dog < Animal
-  acts_as_cached
+  second_level_cache
 end

--- a/test/model/book.rb
+++ b/test/model/book.rb
@@ -6,7 +6,7 @@ ActiveRecord::Base.connection.create_table(:books, force: true) do |t|
 end
 
 class Book < ActiveRecord::Base
-  acts_as_cached
+  second_level_cache
 
   belongs_to :user, counter_cache: true
   has_many :images, as: :imagable

--- a/test/model/image.rb
+++ b/test/model/image.rb
@@ -5,7 +5,7 @@ ActiveRecord::Base.connection.create_table(:images, force: true) do |t|
 end
 
 class Image < ActiveRecord::Base
-  acts_as_cached
+  second_level_cache
 
   belongs_to :imagable, polymorphic: true, counter_cache: true
 end

--- a/test/model/post.rb
+++ b/test/model/post.rb
@@ -5,6 +5,6 @@ ActiveRecord::Base.connection.create_table(:posts, force: true) do |t|
 end
 
 class Post < ActiveRecord::Base
-  acts_as_cached
+  second_level_cache
   belongs_to :topic, touch: true
 end

--- a/test/model/topic.rb
+++ b/test/model/topic.rb
@@ -6,7 +6,7 @@ ActiveRecord::Base.connection.create_table(:topics, force: true) do |t|
 end
 
 class Topic < ActiveRecord::Base
-  acts_as_cached
+  second_level_cache
 
   has_many :posts
 end

--- a/test/model/user.rb
+++ b/test/model/user.rb
@@ -26,7 +26,7 @@ class User < ActiveRecord::Base
   CACHE_VERSION = 3
   serialize :options, Array
   serialize :json_options, JSON if ::ActiveRecord::VERSION::STRING >= '4.1.0'
-  acts_as_cached(version: CACHE_VERSION, expires_in: 3.days)
+  second_level_cache(version: CACHE_VERSION, expires_in: 3.days)
   has_one  :account
   has_one  :forked_user_link, foreign_key: 'forked_to_user_id'
   has_one  :forked_from_user, through: :forked_user_link
@@ -39,7 +39,7 @@ class User < ActiveRecord::Base
 end
 
 class Namespace < ActiveRecord::Base
-  acts_as_cached version: 1, expires_in: 3.days
+  second_level_cache version: 1, expires_in: 3.days
 
   belongs_to :user
 end


### PR DESCRIPTION
这么修改意义在于任何人看到一个 Model 文件里面描述 `acts_as_cached` 的时候，如果他不熟悉，可能不知道这是干嘛，他去搜索也不好找到，但如果改成 `second_level_cache` 就很明确了。