### PR TITLE
用 Model schema 的结构作为 cache version，类似 Rails View cache digest 的机制

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For example, cache User objects:
 
 ```ruby
 class User < ActiveRecord::Base
-  second_level_cache version: 1, expires_in: 1.week
+  second_level_cache expires_in: 1.week
 end
 ```
 
@@ -99,9 +99,9 @@ User.select("id, name").find(1)
 ```ruby
 # user and account's write_second_level_cache operation will invoke after the logger.
 ActiveRecord::Base.transaction do
-   user.save
-   account.save
-   Rails.logger.info "info"
+  user.save
+  account.save
+  Rails.logger.info "info"
 end # <- Cache write
 
 # if you want to do something after user and account's write_second_level_cache operation, do this way:
@@ -135,7 +135,8 @@ you can only change the `cache_key_prefix`:
 SecondLevelCache.configure.cache_key_prefix = "slc1"
 ```
 
-* When schema of your model changed, just change the `version` of the speical model, avoding clear all the cache.
+* SecondLevelCache was added model schema digest as cache version, this means when you add/remove/change columns, the caches of this Model will expires.
+* When your want change the model cache version by manualy, just add the `version` option like this:
 
 ```ruby
 class User < ActiveRecord::Base
@@ -143,7 +144,7 @@ class User < ActiveRecord::Base
 end
 ```
 
-* It provides a great feature, not hits db when fetching record via unique key(not primary key).
+* It provides a great feature, not hits db when fetching record via unique key (not primary key).
 
 ```ruby
 # this will fetch from cache

--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -23,8 +23,8 @@ module SecondLevelCache
       def second_level_cache(options = {})
         @second_level_cache_enabled = true
         @second_level_cache_options = options
-        @second_level_cache_options[:expires_in] ||= 1.week
         @second_level_cache_options[:version] ||= 0
+        @second_level_cache_options[:expires_in] ||= 1.week
         relation.class.send :prepend, SecondLevelCache::ActiveRecord::FinderMethods
         prepend SecondLevelCache::ActiveRecord::Core
       end
@@ -50,8 +50,15 @@ module SecondLevelCache
         @second_level_cache_enabled = old
       end
 
+      # Get MD5 digest of this Model schema
+      # http://api.rubyonrails.org/classes/ActiveRecord/Core/ClassMethods.html#method-i-inspect
       def cache_version
-        second_level_cache_options[:version]
+        return @cache_version if defined? @cache_version
+        # This line is copy from:
+        # https://github.com/rails/rails/blob/f9a5f48/activerecord/lib/active_record/core.rb#L236
+        attr_list = attribute_types.map { |name, type| "#{name}: #{type.type}" } * ', '
+        model_schema_digest = Digest::MD5.hexdigest(attr_list)
+        @cache_version = "#{second_level_cache_options[:version]}/#{model_schema_digest}"
       end
 
       def second_level_cache_key(id)

--- a/test/second_level_cache_test.rb
+++ b/test/second_level_cache_test.rb
@@ -6,7 +6,10 @@ class SecondLevelCacheTest < ActiveSupport::TestCase
   end
 
   def test_should_get_cache_key
-    assert_equal "slc/users/#{@user.id}/#{User::CACHE_VERSION}", @user.second_level_cache_key
+    attr_list = User.attribute_types.map { |name, type| "#{name}: #{type.type}" } * ', '
+    table_digest = Digest::MD5.hexdigest(attr_list)
+    refute_nil table_digest
+    assert_equal "slc/users/#{@user.id}/#{User::CACHE_VERSION}/#{table_digest}", @user.second_level_cache_key
   end
 
   def test_should_write_and_read_cache


### PR DESCRIPTION
## 目的

避免再手动调整 `version` 参数，尤其是有时候表结构变了，会忘了修改 `version`，结果导致上线以后出错。这样的情况我已经不止一次遇到了。尤其是项目复杂的时候，容易漏掉这部分。

## 实现原理

基于 Rails [Model.inspect](http://api.rubyonrails.org/classes/ActiveRecord/Core/ClassMethods.html#method-i-inspect) 为参考，将字段和类型变成这样的结果：

```rb
irb> User.attribute_types.map { |name, type| [name, type.type.to_s] } * ','
"id:integer, login:string, name:string, email:string, password:string"
```

然后在计算 MD5 digest 作为 Model 的 cache version

这样一来，每次应用表增加/删除字段、以及更改字段类型的时候，MD5 digest 都会变化，以达到变更 cache version 的目的。



