### PR TITLE
增加 prelaod 对非 integer 的主键类型的支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 *~
 *.lock
 vendor/bundle
+.idea

--- a/lib/second_level_cache/active_record/preloader.rb
+++ b/lib/second_level_cache/active_record/preloader.rb
@@ -35,6 +35,7 @@ module SecondLevelCache
 
           private
 
+          # test klass primary key is integer type. (rails default)
           def integer?
             primary_key_attribute = klass.attribute_types.select { |name, type| name == User.primary_key }
             if primary_key_attribute.key?(klass.primary_key.to_s)

--- a/lib/second_level_cache/active_record/preloader.rb
+++ b/lib/second_level_cache/active_record/preloader.rb
@@ -11,8 +11,11 @@ module SecondLevelCache
             # NOTICE
             # Rails.cache.read_multi return hash that has keys only hitted.
             # eg. Rails.cache.read_multi(1,2,3) => {2 => hit_value, 3 => hit_value}
-            hitted_ids = records_from_cache.map { |key, _| key.split('/')[2].to_i }
-            missed_ids = ids.map(&:to_i) - hitted_ids
+            hitted_ids = records_from_cache.map do |key, _| 
+              id = key.split('/')[2]
+              integer? ? id.to_i : id
+            end
+            missed_ids = (integer? ? ids.map(&:to_i) : ids) - hitted_ids
 
             ::SecondLevelCache.logger.info "missed ids -> #{missed_ids.inspect} | hitted ids -> #{hitted_ids.inspect}"
 
@@ -31,6 +34,15 @@ module SecondLevelCache
           end
 
           private
+
+          def integer?
+            primary_key_attribute = klass.attribute_types.select { |name, type| name == User.primary_key }
+            if primary_key_attribute.key?(klass.primary_key.to_s)
+              primary_key_attribute[klass.primary_key].type == :integer
+            else
+              true
+            end
+          end
 
           def write_cache(record)
             record.write_second_level_cache

--- a/lib/second_level_cache/active_record/preloader.rb
+++ b/lib/second_level_cache/active_record/preloader.rb
@@ -11,7 +11,7 @@ module SecondLevelCache
             # NOTICE
             # Rails.cache.read_multi return hash that has keys only hitted.
             # eg. Rails.cache.read_multi(1,2,3) => {2 => hit_value, 3 => hit_value}
-            hitted_ids = records_from_cache.map do |key, _| 
+            hitted_ids = records_from_cache.map do |key, _|
               id = key.split('/')[2]
               integer? ? id.to_i : id
             end
@@ -37,7 +37,7 @@ module SecondLevelCache
 
           # test klass primary key is integer type. (rails default)
           def integer?
-            primary_key_attribute = klass.attribute_types.select { |name, type| name == User.primary_key }
+            primary_key_attribute = klass.attribute_types.select { |name, _| name == User.primary_key }
             if primary_key_attribute.key?(klass.primary_key.to_s)
               primary_key_attribute[klass.primary_key].type == :integer
             else

--- a/lib/second_level_cache/version.rb
+++ b/lib/second_level_cache/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module SecondLevelCache
   VERSION = '2.3.1'.freeze
 end

--- a/test/model/order.rb
+++ b/test/model/order.rb
@@ -1,0 +1,12 @@
+ActiveRecord::Base.connection.create_table(:orders, force: true, id: :uuid) do |t|
+  t.text :body
+  t.string :title
+
+  t.timestamps null: false
+end
+
+class Order < ActiveRecord::Base
+  second_level_cache
+
+  has_many :order_items
+end

--- a/test/model/order_item.rb
+++ b/test/model/order_item.rb
@@ -1,0 +1,10 @@
+ActiveRecord::Base.connection.create_table(:order_items, force: true, id: :uuid) do |t|
+  t.text :body
+  t.string :slug
+  t.string :order_id
+end
+
+class OrderItem < ActiveRecord::Base
+  second_level_cache
+  belongs_to :order, touch: true
+end

--- a/test/model/user.rb
+++ b/test/model/user.rb
@@ -29,7 +29,7 @@ class User < ActiveRecord::Base
 
   serialize :options, Array
   serialize :json_options, JSON if ::ActiveRecord::VERSION::STRING >= '4.1.0'
-  store :extras, accessors: [:tagline, :gender]
+  store :extras, accessors: %I[tagline gender]
 
   has_one  :account
   has_one  :forked_user_link, foreign_key: 'forked_to_user_id'
@@ -39,7 +39,7 @@ class User < ActiveRecord::Base
   has_many :books
   has_many :images, as: :imagable
 
-  enum status: [:active, :archived]
+  enum status: %I[active archived]
 end
 
 class Namespace < ActiveRecord::Base

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -20,7 +20,7 @@ class PersistenceTest < ActiveSupport::TestCase
   def test_should_update_cache_after_touch
     old_updated_time = @user.updated_at
     @user.touch
-    assert !(old_updated_time == @user.updated_at)
+    assert old_updated_time != @user.updated_at
     new_user = User.find @user.id
     assert_equal new_user, @user
   end

--- a/test/preloader_non_integer_test.rb
+++ b/test/preloader_non_integer_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class PreloaderNonIntegerTest < ActiveSupport::TestCase
+  def test_belongs_to_preload_caches_includes_uuid
+  	orders = [
+      Order.create(id: '15944214-e4df-4e46-8d56-1f5864a0b90c', title: 'title1', body: 'body1'),
+      Order.create(id: '25944214-e4df-4e46-8d56-1f5864a0b90c', title: 'title2', body: 'body2'),
+      Order.create(id: '35944214-e4df-4e46-8d56-1f5864a0b90c', title: 'title3', body: 'body3')
+    ]
+    orders.each_with_index { |order, i| order.order_items.create(body: "order_item#{order.id}", id: "1#{i}944214-e4df-4e46-8d56-1f5864a0b90c") }
+
+    results = nil
+    assert_queries(1) do
+    	results = OrderItem.includes(:order).order('id ASC').to_a
+    end
+    assert_equal orders, results.map(&:order)
+  end
+
+  def test_belongs_to_when_read_multi_missed_from_cache_ar_will_fetch_missed_records_from_db_uuid
+  	orders = [
+      Order.create(id: '15944214-e4df-4e46-8d56-1f5864a0b90c', title: 'title1', body: 'body1'),
+      Order.create(id: '25944214-e4df-4e46-8d56-1f5864a0b90c', title: 'title2', body: 'body2'),
+      Order.create(id: '35944214-e4df-4e46-8d56-1f5864a0b90c', title: 'title3', body: 'body3')
+    ]
+    orders.each_with_index { |order, i| order.order_items.create(body: "order_item#{order.id}", id: "1#{i}944214-e4df-4e46-8d56-1f5864a0b90c") }
+    expired_order = orders.first
+    expired_order.expire_second_level_cache
+
+    results = nil
+    assert_queries(2) do
+      assert_sql(/WHERE\s\"orders\"\.\"id\"\s=\s'#{expired_order.id}'/m) do
+        results = OrderItem.includes(:order).order('id ASC').to_a
+      end
+    end
+
+    assert_equal orders, results.map(&:order)
+  end
+
+  def test_has_many_preloader_returns_correct_results
+    order = Order.create(id: '15944214-e4df-4e46-8d56-1f5864a0b90c')
+    OrderItem.create(id: '11944214-e4df-4e46-8d56-1f5864a0b90c')
+    order_item = order.order_items.create(id: '12944214-e4df-4e46-8d56-1f5864a0b90c')
+
+    assert_equal [order_item], Order.includes(:order_items).find('15944214-e4df-4e46-8d56-1f5864a0b90c').order_items
+  end
+
+  def test_has_one_preloader_returns_correct_results
+    user = User.create(id: 1)
+    Account.create(id: 1)
+    account = user.create_account
+
+    assert_equal account, User.includes(:account).find(1).account
+  end
+end

--- a/test/preloader_non_integer_test.rb
+++ b/test/preloader_non_integer_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class PreloaderNonIntegerTest < ActiveSupport::TestCase
   def test_belongs_to_preload_caches_includes_uuid
-  	orders = [
+    orders = [
       Order.create(id: '15944214-e4df-4e46-8d56-1f5864a0b90c', title: 'title1', body: 'body1'),
       Order.create(id: '25944214-e4df-4e46-8d56-1f5864a0b90c', title: 'title2', body: 'body2'),
       Order.create(id: '35944214-e4df-4e46-8d56-1f5864a0b90c', title: 'title3', body: 'body3')
@@ -11,13 +11,13 @@ class PreloaderNonIntegerTest < ActiveSupport::TestCase
 
     results = nil
     assert_queries(1) do
-    	results = OrderItem.includes(:order).order('id ASC').to_a
+      results = OrderItem.includes(:order).order('id ASC').to_a
     end
     assert_equal orders, results.map(&:order)
   end
 
   def test_belongs_to_when_read_multi_missed_from_cache_ar_will_fetch_missed_records_from_db_uuid
-  	orders = [
+    orders = [
       Order.create(id: '15944214-e4df-4e46-8d56-1f5864a0b90c', title: 'title1', body: 'body1'),
       Order.create(id: '25944214-e4df-4e46-8d56-1f5864a0b90c', title: 'title2', body: 'body2'),
       Order.create(id: '35944214-e4df-4e46-8d56-1f5864a0b90c', title: 'title3', body: 'body3')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,8 @@ require 'model/book'
 require 'model/image'
 require 'model/topic'
 require 'model/post'
+require 'model/order'
+require 'model/order_item'
 require 'model/account'
 require 'model/animal'
 


### PR DESCRIPTION
在使用 uuid 为主键的情况下, 当调用 `Topic.includes(:posts)` 时, preload.rb 中是认为主键一定为 `integer` 类型的. 所以当主键全部为 uuid 的时候是不支持的(pg)

代码中保留了原来的逻辑, 并添加了针对主键为非 integer 时候的处理. 

sqlite3 的场景已经在 test 中体现了, 只能使用 string 类型.
pg 的场景已经在我自己的产品环境中测试了,通过.
mysql 的场景没有真实测试过.