### PR TITLE
Rails 5.1 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ Style/AsciiComments:
 Style/IfUnlessModifier:
   Enabled: false
 
-Style/AmbiguousBlockAssociation:
+Lint/AmbiguousBlockAssociation:
   Enabled: false
 
 Metrics/LineLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
 gemfile:
   - gemfiles/Gemfile-5-0
   - gemfiles/Gemfile-5-0-1
+  - gemfiles/Gemfile-5-1
   - gemfiles/Gemfile-edge
 matrix:
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rails', '~> 5.0.0'
+gem 'rails', '~> 5.1.0'

--- a/gemfiles/Gemfile-4-0
+++ b/gemfiles/Gemfile-4-0
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec :path => '..'
-
-gem 'rails', "~> 4.0.0"

--- a/gemfiles/Gemfile-4-1
+++ b/gemfiles/Gemfile-4-1
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec :path => '..'
-
-gem 'rails', "~> 4.1.0"

--- a/gemfiles/Gemfile-4-2
+++ b/gemfiles/Gemfile-4-2
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec :path => '..'
-
-gem 'rails', "~> 4.2.0"

--- a/gemfiles/Gemfile-5-1
+++ b/gemfiles/Gemfile-5-1
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec :path => '..'
+
+gem 'rails', '5.1.0'

--- a/lib/second_level_cache/active_record/finder_methods.rb
+++ b/lib/second_level_cache/active_record/finder_methods.rb
@@ -19,7 +19,6 @@ module SecondLevelCache
         return super(id) unless select_all_column?
 
         id = id.id if ActiveRecord::Base == id
-
         if cachable?
           record = @klass.read_second_level_cache(id)
           if record
@@ -61,12 +60,13 @@ module SecondLevelCache
 
       private
 
+      # readonly_value - active_record/relation/query_methods.rb Rails 5.1 true/false
       def cachable?
         limit_one? &&
           order_values.blank? &&
           includes_values.blank? &&
           preload_values.blank? &&
-          readonly_value.nil? &&
+          !readonly_value &&
           joins_values.blank? &&
           !@klass.locking_enabled? &&
           where_clause_match_equality?

--- a/lib/second_level_cache/active_record/finder_methods.rb
+++ b/lib/second_level_cache/active_record/finder_methods.rb
@@ -66,7 +66,7 @@ module SecondLevelCache
           order_values.blank? &&
           includes_values.blank? &&
           preload_values.blank? &&
-          !readonly_value &&
+          readonly_value.blank? &&
           joins_values.blank? &&
           !@klass.locking_enabled? &&
           where_clause_match_equality?

--- a/second_level_cache.gemspec
+++ b/second_level_cache.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = SecondLevelCache::VERSION
 
-  gem.add_runtime_dependency 'activesupport', ['>= 5.0.0.beta3', '< 5.1.0']
-  gem.add_runtime_dependency 'activerecord', ['>= 5.0.0.beta3', '< 5.1.0']
+  gem.add_runtime_dependency 'activesupport', ['>= 5.0.0', '< 5.2']
+  gem.add_runtime_dependency 'activerecord', ['>= 5.0.0', '< 5.2']
 
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'rake'

--- a/test/model/user.rb
+++ b/test/model/user.rb
@@ -49,6 +49,6 @@ class Namespace < ActiveRecord::Base
 end
 
 class ForkedUserLink < ActiveRecord::Base
-  belongs_to :forked_from_user, class_name: User
-  belongs_to :forked_to_user, class_name: User
+  belongs_to :forked_from_user, class_name: 'User'
+  belongs_to :forked_to_user, class_name: 'User'
 end


### PR DESCRIPTION
@hooopo 

```
readonly_value 
```
这个行为修改了，可能会导致老版本有问题，你还记得以前的值是什么样的么？

顺便说一下，这块 Rails 迭代新版本的时候，问题太难查了，以后得慢慢把这些调用 Active Record 内部的地方注释标注清楚来源，这样下次可以快速检查相关文件的变化。