### PR TITLE
fix: delete uniq key cache when object is not found

### DIFF
--- a/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
+++ b/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
@@ -9,8 +9,10 @@ module SecondLevelCache
         if obj_id
           begin
             return find(obj_id)
-          rescue StandardError
+          rescue ActiveRecord::RecordNotFound
             SecondLevelCache.cache_store.delete(cache_key)
+          rescue StandardError
+            return nil
           end
         end
 

--- a/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
+++ b/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
@@ -9,7 +9,7 @@ module SecondLevelCache
         if obj_id
           begin
             return find(obj_id)
-          rescue ActiveRecord::RecordNotFound
+          rescue ::ActiveRecord::RecordNotFound
             SecondLevelCache.cache_store.delete(cache_key)
           rescue StandardError
             return nil

--- a/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
+++ b/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
@@ -10,7 +10,7 @@ module SecondLevelCache
           begin
             return find(obj_id)
           rescue StandardError
-            return nil
+            SecondLevelCache.cache_store.delete(cache_key)
           end
         end
 

--- a/test/fetch_by_uniq_key_test.rb
+++ b/test/fetch_by_uniq_key_test.rb
@@ -47,6 +47,14 @@ class FetchByUinqKeyTest < ActiveSupport::TestCase
     assert_nil Post.fetch_by_uniq_keys(topic_id: 3, slug: "foobar")
   end
 
+  def test_should_work_when_delete_and_create_the_same_value
+    assert_not_nil Post.fetch_by_uniq_keys(topic_id: 2, slug: "foobar")
+    @post.destroy
+    assert_nil Post.fetch_by_uniq_keys(topic_id: 2, slug: "foobar")
+    @post = Post.create(topic_id: 2, slug: "foobar")
+    assert_not_nil Post.fetch_by_uniq_keys(topic_id: 2, slug: "foobar")
+  end
+
   def test_should_work_with_fetch_by_uniq_key
     user = User.fetch_by_uniq_key(@user.name, :name)
     assert_equal user, @user


### PR DESCRIPTION
When using fetch_by_uniq_keys method, the cache_uniq_key and value still exists after destroying the object. If creating the same where_values and using fetch_by_uniq_keys, it would return nil. But actually it is not a null object.

Solve it by deleting the cache_key when not finding the object.