### PR TITLE
修复当联合主键被updated时fetch_by_uniq_keys获取到旧的对象问题

### DIFF
--- a/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
+++ b/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
@@ -9,8 +9,10 @@ module SecondLevelCache
         if obj_id
           begin
             return find(obj_id)
-          rescue StandardError
+          rescue ::ActiveRecord::RecordNotFound
             SecondLevelCache.cache_store.delete(cache_key)
+          rescue StandardError
+            return nil
           end
         end
 

--- a/lib/second_level_cache/mixin.rb
+++ b/lib/second_level_cache/mixin.rb
@@ -87,18 +87,18 @@ module SecondLevelCache
     def expire_changed_association_uniq_keys
       uniq_keys = klass.send(:read_uniq_keys)
 
-      changed_keys = uniq_keys.select do |keys|
-        (previous_changes.keys | keys).size > 0
+      changed_keys = uniq_keys.reject do |keys|
+        (previous_changes.keys | keys).empty?
       end
 
       changed_keys.each do |keys|
         where_values = {}
         keys.each do |key|
-          where_values[key] = if previous_changes.has_key?(key)
-            previous_changes[key][0]
-          else
-            read_attribute(key)
-          end
+          where_values[key] = if previous_changes.key?(key)
+                                previous_changes[key][0]
+                              else
+                                read_attribute(key)
+                              end
         end
         SecondLevelCache.cache_store.delete(klass.send(:cache_uniq_key, where_values))
       end

--- a/test/fetch_by_uniq_key_test.rb
+++ b/test/fetch_by_uniq_key_test.rb
@@ -53,11 +53,11 @@ class FetchByUinqKeyTest < ActiveSupport::TestCase
   end
 
   def test_should_hit_db_using_fetch_by_uniq_key_after_update_uniq_key
-    post_1 = Post.create slug: "foobar111", topic_id: 2, user_id: 1, iid: 1
+    post_old = Post.create slug: "foobar111", topic_id: 2, user_id: 1, iid: 1
     assert_queries do
       Post.fetch_by_uniq_keys(user_id: 1, iid: 1)
     end
-    post_1.update_attributes!(iid: 11)
+    post_old.update_attributes!(iid: 11)
     assert_nil Post.fetch_by_uniq_keys(user_id: 1, iid: 1)
     post = Post.create slug: "foobar222", topic_id: 3, user_id: 1, iid: 1
     post_cache = Post.fetch_by_uniq_keys(user_id: 1, iid: 1)
@@ -68,14 +68,14 @@ class FetchByUinqKeyTest < ActiveSupport::TestCase
   end
 
   def test_should_hit_db_using_fetch_by_uniq_key_after_rebuild_record
-    post_1 = Post.create slug: "foobar333", topic_id: 5, user_id: 2, iid: 2
+    post_old = Post.create slug: "foobar333", topic_id: 5, user_id: 2, iid: 2
     assert_queries do
       Post.fetch_by_uniq_keys(user_id: 2, iid: 2)
     end
-    post_1.destroy
+    post_old.destroy
     assert_nil Post.fetch_by_uniq_keys(user_id: 2, iid: 2)
-    post_2 = Post.create slug: "foobar444", topic_id: 5, user_id: 2, iid: 2
+    post_new = Post.create slug: "foobar444", topic_id: 5, user_id: 2, iid: 2
     post_cache = Post.fetch_by_uniq_keys(user_id: 2, iid: 2)
-    assert_equal post_2, post_cache
+    assert_equal post_new, post_cache
   end
 end

--- a/test/fetch_by_uniq_key_test.rb
+++ b/test/fetch_by_uniq_key_test.rb
@@ -51,4 +51,31 @@ class FetchByUinqKeyTest < ActiveSupport::TestCase
     user = User.fetch_by_uniq_key(@user.name, :name)
     assert_equal user, @user
   end
+
+  def test_should_hit_db_using_fetch_by_uniq_key_after_update_uniq_key
+    post_1 = Post.create slug: "foobar111", topic_id: 2, user_id: 1, iid: 1
+    assert_queries do
+      Post.fetch_by_uniq_keys(user_id: 1, iid: 1)
+    end
+    post_1.update_attributes!(iid: 11)
+    assert_nil Post.fetch_by_uniq_keys(user_id: 1, iid: 1)
+    post = Post.create slug: "foobar222", topic_id: 3, user_id: 1, iid: 1
+    post_cache = Post.fetch_by_uniq_keys(user_id: 1, iid: 1)
+    assert_equal post, post_cache
+    assert_queries do
+      Post.fetch_by_uniq_keys(user_id: 1, iid: 11)
+    end
+  end
+
+  def test_should_hit_db_using_fetch_by_uniq_key_after_rebuild_record
+    post_1 = Post.create slug: "foobar333", topic_id: 5, user_id: 2, iid: 2
+    assert_queries do
+      Post.fetch_by_uniq_keys(user_id: 2, iid: 2)
+    end
+    post_1.destroy
+    assert_nil Post.fetch_by_uniq_keys(user_id: 2, iid: 2)
+    post_2 = Post.create slug: "foobar444", topic_id: 5, user_id: 2, iid: 2
+    post_cache = Post.fetch_by_uniq_keys(user_id: 2, iid: 2)
+    assert_equal post_2, post_cache
+  end
 end

--- a/test/model/post.rb
+++ b/test/model/post.rb
@@ -4,6 +4,8 @@ ActiveRecord::Base.connection.create_table(:posts, force: true) do |t|
   t.text :body
   t.string :slug
   t.integer :topic_id
+  t.integer :user_id
+  t.integer :iid
 end
 
 class Post < ActiveRecord::Base


### PR DESCRIPTION
以下场景下 fetch_by_uniq_keys 获取到了错误的对象：

#### 前提条件：
 fetch_by_uniq_keys 的参数作为联合主键（假设是：key_1: 'aaa', key_2: 'bbb'），且不在 belongs_to 关系中时。

#### 场景：
1. 记录A的联合主键中一个或多个被update时，例如 key_1: 'aaa', key_2: 'bbb' -> key_1: 'aaa', key_2: 'ccc'
2. 记录A被 destroy 

这两种情况都没有直接清除 cache_uniq_key，如果此时有另一个记录B 刚好从key_1: 'xxx', key_2: 'yyy' -> key_1: 'aaa', key_2: 'bbb'，或者是新建的一个新记录 key_1: 'aaa', key_2: 'bbb'，这种情况DB的联合唯一索引也是条件允许的。 那么再次 fetch_by_uniq_keys(key_1: 'aaa', key_2: 'bbb') 得到的是记录A，对应场景2则直接返回nil，预期应该是得到记录B。

具体场景也可以看以下测试用例 ：）
