### PR TITLE
Fix cache expire issue for SoftDelete cases

### DIFF
--- a/lib/second_level_cache/active_record/base.rb
+++ b/lib/second_level_cache/active_record/base.rb
@@ -6,7 +6,7 @@ module SecondLevelCache
       def self.prepended(base)
         base.after_commit :update_second_level_cache, on: :update
         base.after_commit :write_second_level_cache, on: :create
-        if defined?(::Paranoia)
+        if defined?(::Paranoia) || column_names.include?("deleted_at")
           base.after_destroy :expire_second_level_cache
         else
           base.after_commit :expire_second_level_cache, on: :destroy


### PR DESCRIPTION
许多软删除的实现往往都是有个 `deleted_at` 字段来表示是否软删除，删除通过 `update` 的方式更新 `deleted_at`，删除的时候会触发 second_level_cache 的 `after_commit on: :update` 从而导致已被软删除的数据重新又写入到 `cache`。

我上次处理过 https://github.com/hooopo/second_level_cache/pull/90/commits/de65f1eca2558e594a4b70d21f0af4fc4aaca189 但实际用的时候发现如果自定义的 SoftDelete 的 callback 处理得不好还是会出问题。

所以稳妥的方式还是得像 `Pandora` 那样处理，确保  `after_destroy` 的时候直接清理 cache。

所以我们只需要判断表包含有 `deleted_at` 字段按这个方式处理即可（就算误判也无影响）
