### PR TITLE
Revert "Fix cache expire issue for SoftDelete cases"

### DIFF
--- a/lib/second_level_cache/active_record/base.rb
+++ b/lib/second_level_cache/active_record/base.rb
@@ -6,7 +6,7 @@ module SecondLevelCache
       def self.prepended(base)
         base.after_commit :update_second_level_cache, on: :update
         base.after_commit :write_second_level_cache, on: :create
-        if defined?(::Paranoia) || column_names.include?("deleted_at")
+        if defined?(::Paranoia)
           base.after_destroy :expire_second_level_cache
         else
           base.after_commit :expire_second_level_cache, on: :destroy


### PR DESCRIPTION
Reverts hooopo/second_level_cache#91

prepend 阶段只有 ActiveRecord::Base，无法探测到实际 Model 的字段，这个方法没用。

其他有类似场景的用户，可以单独在软删除的时候处理调用 `after_destroy :expire_second_level_cache`

比如：

```rb
class Post < ActiveRecord::Base
  after_destroy :expire_second_level_cache
end
```