### PR TITLE
Fix: cache is incorrect after destroy record and create same record

### DIFF
--- a/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
+++ b/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
@@ -6,19 +6,16 @@ module SecondLevelCache
       def fetch_by_uniq_keys(where_values)
         cache_key = cache_uniq_key(where_values)
         obj_id = SecondLevelCache.cache_store.read(cache_key)
-        if obj_id
-          begin
-            return find(obj_id)
-          rescue StandardError
-            return nil
-          end
-        end
 
+        record = find(obj_id) rescue nil if obj_id
+        return record if record
         record = where(where_values).first
-        return nil unless record
-
-        record.tap do |r|
-          SecondLevelCache.cache_store.write(cache_key, r.id)
+        if record
+          SecondLevelCache.cache_store.write(cache_key, record.id)
+          return record
+        else
+          SecondLevelCache.cache_store.delete(cache_key)
+          return nil
         end
       end
 

--- a/test/active_record_test_case_helper.rb
+++ b/test/active_record_test_case_helper.rb
@@ -76,6 +76,16 @@ module ActiveRecordTestCaseHelper
     model.column_names.include?(column_name.to_s)
   end
 
+  def savepoint(&block)
+    if ActiveRecord::Base.connection.supports_savepoints?
+      ActiveRecord::Base.connection.begin_transaction(joinable: false)
+      block.call
+      ActiveRecord::Base.connection.rollback_transaction
+    else
+      block.call
+    end
+  end
+
   class SQLCounter
     class << self
       attr_accessor :ignored_sql, :log, :log_all


### PR DESCRIPTION
删除旧对象后，再次创建相同的对象，fetch_by_uniq_keys 返回 nil
```
uniq_key = { email: "foo@bar.com" }
old_user = User.create(uniq_key)
new_user = old_user.deep_dup
User.fetch_by_uniq_keys(uniq_key)  # 写入缓存 uniq_key_User_email_foo@bar.com，对应 old_user.id
old_user.destroy  # 上面的缓存未失效
new_user.save
User.fetch_by_uniq_keys(uniq_key)  # 读取到之前的 uniq_key_User_email_foo@bar.com 缓存，返回 nil
```