### PR TITLE
fix(fetch_by_uniq_keys): cache is incorrect when A record modified uniq key and B reocrd used old uniq key of A record

### DIFF
--- a/test/active_record_test_case_helper.rb
+++ b/test/active_record_test_case_helper.rb
@@ -76,13 +76,13 @@ module ActiveRecordTestCaseHelper
     model.column_names.include?(column_name.to_s)
   end
 
-  def savepoint(&block)
+  def savepoint
     if ActiveRecord::Base.connection.supports_savepoints?
       ActiveRecord::Base.connection.begin_transaction(joinable: false)
-      block.call
+      yield
       ActiveRecord::Base.connection.rollback_transaction
     else
-      block.call
+      yield
     end
   end
 

--- a/test/fetch_by_uniq_key_test.rb
+++ b/test/fetch_by_uniq_key_test.rb
@@ -14,6 +14,18 @@ class FetchByUinqKeyTest < ActiveSupport::TestCase
     assert_equal User.send(:cache_uniq_key, foo: 1, bar: nil), "uniq_key_User_foo_1,bar_"
     long_val = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     assert_equal User.send(:cache_uniq_key, foo: 1, bar: long_val), "uniq_key_User_foo_1,bar_#{Digest::MD5.hexdigest(long_val)}"
+    assert Contribution.send(:cache_uniq_key, user_id: 1, date: Date.today), "uniq_key_Contribution_user_id_1,date_#{Date.today.to_s}"
+  end
+
+  def test_compare_record_attributes_with_where_values
+    book = Book.new(title: 'foobar')
+    assert Book.send(:compare_record_attributes_with_where_values, book, title: :foobar)
+    book.discount_percentage = 60.00
+    assert Book.send(:compare_record_attributes_with_where_values, book, discount_percentage: '60')
+    book.publish_date = Date.today
+    assert Book.send(:compare_record_attributes_with_where_values, book, publish_date: Date.today.to_s)
+    book.title = nil
+    assert Book.send(:compare_record_attributes_with_where_values, book, title: nil)
   end
 
   def test_should_query_from_db_using_primary_key
@@ -59,10 +71,22 @@ class FetchByUinqKeyTest < ActiveSupport::TestCase
       new_user = old_user.deep_dup
       assert_equal old_user, User.fetch_by_uniq_keys(uniq_key)
       old_user.destroy
-      # FIXME: sql queries count should be one
+
+      # Dirty id cache should be removed
       assert_queries(2) { assert_nil User.fetch_by_uniq_keys(uniq_key) }
       assert_queries(1) { assert_nil User.fetch_by_uniq_keys(uniq_key) }
+
       new_user.save
+      assert_equal new_user, User.fetch_by_uniq_keys(uniq_key)
+    end
+  end
+
+  def test_should_return_correct_when_old_record_modify_uniq_key_and_new_record_use_same_uniq_key
+    savepoint do
+      uniq_key = { email: @user.email }
+      assert_equal @user, User.fetch_by_uniq_keys(uniq_key)
+      @user.update_attribute(:email, "#{Time.now.to_i}@foobar.com")
+      new_user = User.create(uniq_key)
       assert_equal new_user, User.fetch_by_uniq_keys(uniq_key)
     end
   end

--- a/test/fetch_by_uniq_key_test.rb
+++ b/test/fetch_by_uniq_key_test.rb
@@ -14,16 +14,16 @@ class FetchByUinqKeyTest < ActiveSupport::TestCase
     assert_equal User.send(:cache_uniq_key, foo: 1, bar: nil), "uniq_key_User_foo_1,bar_"
     long_val = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     assert_equal User.send(:cache_uniq_key, foo: 1, bar: long_val), "uniq_key_User_foo_1,bar_#{Digest::MD5.hexdigest(long_val)}"
-    assert Contribution.send(:cache_uniq_key, user_id: 1, date: Date.today), "uniq_key_Contribution_user_id_1,date_#{Date.today.to_s}"
+    assert Contribution.send(:cache_uniq_key, user_id: 1, date: Time.current.to_date), "uniq_key_Contribution_user_id_1,date_#{Time.current.to_date}"
   end
 
   def test_compare_record_attributes_with_where_values
-    book = Book.new(title: 'foobar')
+    book = Book.new(title: "foobar")
     assert Book.send(:compare_record_attributes_with_where_values, book, title: :foobar)
     book.discount_percentage = 60.00
-    assert Book.send(:compare_record_attributes_with_where_values, book, discount_percentage: '60')
-    book.publish_date = Date.today
-    assert Book.send(:compare_record_attributes_with_where_values, book, publish_date: Date.today.to_s)
+    assert Book.send(:compare_record_attributes_with_where_values, book, discount_percentage: "60")
+    book.publish_date = Time.current.to_date
+    assert Book.send(:compare_record_attributes_with_where_values, book, publish_date: Time.current.to_date.to_s)
     book.title = nil
     assert Book.send(:compare_record_attributes_with_where_values, book, title: nil)
   end

--- a/test/model/book.rb
+++ b/test/model/book.rb
@@ -4,7 +4,9 @@ ActiveRecord::Base.connection.create_table(:books, force: true) do |t|
   t.string  :title
   t.string  :body
   t.integer :user_id
+  t.decimal :discount_percentage, precision: 5, scale: 2
   t.integer :images_count, default: 0
+  t.date    :publish_date
 end
 
 class Book < ActiveRecord::Base

--- a/test/model/contribution.rb
+++ b/test/model/contribution.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+ActiveRecord::Base.connection.create_table(:contributions, force: true) do |t|
+  t.integer :user_id
+  t.text    :data
+  t.date    :date
+end
+
+class Contribution < ActiveRecord::Base
+  second_level_cache
+
+  validates_uniqueness_of :user_id, scope: :date, if: -> { user_id_changed? || date_changed? }
+  belongs_to :user
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,7 @@ require "model/order"
 require "model/order_item"
 require "model/account"
 require "model/animal"
+require "model/contribution"
 
 DatabaseCleaner[:active_record].strategy = :truncation
 


### PR DESCRIPTION
- Fix fetch_by_uniq_keys  
```
uniq_key = { email: 'foobar@test.com' }
a = User.create(uniq_key)
User.fetch_by_uniq_keys(uniq_key)  # uniq_key_User_email_foobar@test.com 被写入缓存
a.update_attribute(:email, 'modifed@test.com')
User.fetch_by_uniq_keys(uniq_key)  # uniq_key 被更改了，期望返回 nil，但实际这里返回了 a
```
- Fix cache_uniq_key  
```
Contribution.fetch_by_uniq_keys(user_id: 1, date: Date.today)  # raise undefined method `size' for Date type
```
- Add compare_record_attributes_with_where_values
认证 fetch_by_uniq_keys 结果的正确性