### PR TITLE
Preloader support has_one and fix double questions

### DIFF
--- a/lib/second_level_cache/active_record.rb
+++ b/lib/second_level_cache/active_record.rb
@@ -23,5 +23,5 @@ ActiveSupport.on_load(:active_record) do
   ActiveRecord::Relation.send(:prepend, SecondLevelCache::ActiveRecord::FinderMethods)
   # Rails 5.2 has removed ActiveRecord::Associations::Preloader::BelongsTo
   # https://github.com/rails/rails/pull/31079
-  ActiveRecord::Associations::Preloader::Association.send(:prepend, SecondLevelCache::ActiveRecord::Associations::Preloader::BelongsTo)
+  ActiveRecord::Associations::Preloader::Association.send(:prepend, SecondLevelCache::ActiveRecord::Associations::Preloader)
 end

--- a/lib/second_level_cache/active_record/preloader.rb
+++ b/lib/second_level_cache/active_record/preloader.rb
@@ -3,41 +3,45 @@
 module SecondLevelCache
   module ActiveRecord
     module Associations
-      class Preloader
-        module BelongsTo
-          def records_for(ids, &block)
-            return super(ids, &block) unless reflection.is_a?(::ActiveRecord::Reflection::BelongsToReflection)
-            return super(ids, &block) unless klass.second_level_cache_enabled?
-
+      module Preloader
+        def records_for(ids, &block)
+          return super(ids, &block) unless klass.second_level_cache_enabled?
+          if reflection.is_a?(::ActiveRecord::Reflection::BelongsToReflection)
             map_cache_keys = ids.map { |id| klass.second_level_cache_key(id) }
-            records_from_cache = ::SecondLevelCache.cache_store.read_multi(*map_cache_keys)
-            # NOTICE
-            # Rails.cache.read_multi return hash that has keys only hitted.
-            # eg. Rails.cache.read_multi(1,2,3) => {2 => hit_value, 3 => hit_value}
-            hitted_ids = records_from_cache.map { |key, _| key.split("/")[2] }
-            missed_ids = ids.map(&:to_s) - hitted_ids
-
-            ::SecondLevelCache.logger.info "missed ids -> #{missed_ids.join(',')} | hitted ids -> #{hitted_ids.join(',')}"
-
-            record_marshals = RecordMarshal.load_multi(records_from_cache.values)
-
-            if missed_ids.empty?
-              return SecondLevelCache::RecordRelation.new(record_marshals)
-            end
-
-            records_from_db = super(missed_ids, &block)
-            records_from_db.map do |r|
-              write_cache(r)
-            end
-
-            SecondLevelCache::RecordRelation.new(records_from_db + record_marshals)
+          elsif reflection.is_a?(::ActiveRecord::Reflection::HasOneReflection)
+            map_uniq_keys = ids.map { |id| klass.send(:cache_uniq_key, association_key_name => id) }
+            ids_ = ::SecondLevelCache.cache_store.read_multi(*map_uniq_keys).values
+            map_cache_keys = ids_.map { |id| klass.second_level_cache_key(id) }
+          else
+            return super(ids, &block)
           end
+          records_from_cache = ::SecondLevelCache.cache_store.read_multi(*map_cache_keys)
+          record_marshals = RecordMarshal.load_multi(records_from_cache.values)
 
-          private
+          # NOTICE
+          # Rails.cache.read_multi return hash that has keys only hitted.
+          # eg. Rails.cache.read_multi(1,2,3) => {2 => hit_value, 3 => hit_value}
+          hitted_ids = record_marshals.map { |record| record.read_attribute(association_key_name) }
+          missed_ids = ids.map(&:to_s) - hitted_ids.map(&:to_s)
+          ::SecondLevelCache.logger.info("missed #{association_key_name} -> #{missed_ids.join(',')} | hitted #{association_key_name} -> #{hitted_ids.join(',')}")
+          return SecondLevelCache::RecordRelation.new(record_marshals) if missed_ids.empty?
 
-          def write_cache(record)
-            record.write_second_level_cache
+          records_from_db = super(missed_ids, &block)
+          records_from_db.map { |r| write_cache(r) }
+
+          SecondLevelCache::RecordRelation.new(records_from_db + record_marshals)
+        end
+
+        private
+
+        def write_cache(record)
+          if reflection.is_a?(::ActiveRecord::Reflection::HasOneReflection)
+            ::SecondLevelCache.cache_store.write(
+              klass.send(:cache_uniq_key, association_key_name => record.read_attribute(association_key_name)),
+              record.id
+            )
           end
+          record.write_second_level_cache
         end
       end
     end

--- a/lib/second_level_cache/active_record/preloader.rb
+++ b/lib/second_level_cache/active_record/preloader.rb
@@ -16,7 +16,13 @@ module SecondLevelCache
             return super(ids, &block)
           end
           records_from_cache = ::SecondLevelCache.cache_store.read_multi(*map_cache_keys)
-          record_marshals = RecordMarshal.load_multi(records_from_cache.values)
+          record_marshals = RecordMarshal.load_multi(records_from_cache.values) do |record|
+            # This block is copy from:
+            # https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/associations/preloader/association.rb#L101
+            owner = owners_by_key[convert_key(record[association_key_name])].first
+            association = owner.association(reflection.name)
+            association.set_inverse_instance(record)
+          end
 
           # NOTICE
           # Rails.cache.read_multi return hash that has keys only hitted.

--- a/lib/second_level_cache/mixin.rb
+++ b/lib/second_level_cache/mixin.rb
@@ -83,8 +83,8 @@ module SecondLevelCache
     alias update_second_level_cache write_second_level_cache
 
     def expire_changed_association_uniq_keys
-      reflections = klass.reflections.select { |_, reflection| reflection.belongs_to? }
-      changed_keys = reflections.map { |_, reflection| reflection.foreign_key } & previous_changes.keys
+      changed_keys = klass.reflect_on_all_associations(:belongs_to).map(&:foreign_key)
+                          .map(&:to_s) & previous_changes.keys
       changed_keys.each do |key|
         SecondLevelCache.cache_store.delete(klass.send(:cache_uniq_key, key => previous_changes[key][0]))
       end

--- a/lib/second_level_cache/record_marshal.rb
+++ b/lib/second_level_cache/record_marshal.rb
@@ -15,7 +15,7 @@ module RecordMarshal
     end
 
     # load a cached record
-    def load(serialized)
+    def load(serialized, &block)
       return unless serialized
       # fix issues 19
       # fix 2.1.2 object.changed? ActiveRecord::SerializationTypeMismatch: Attribute was supposed to be a Hash, but was a String. -- "{:a=>\"t\", :b=>\"x\"}"
@@ -45,11 +45,11 @@ module RecordMarshal
         attributes[key] = value[attributes[key]] if attributes[key].is_a?(String)
       end
 
-      klass.instantiate(attributes)
+      klass.instantiate(attributes, &block)
     end
 
-    def load_multi(serializeds)
-      serializeds.map { |serialized| load(serialized) }
+    def load_multi(serializeds, &block)
+      serializeds.map { |serialized| load(serialized, &block) }
     end
   end
 end

--- a/test/belongs_to_association_test.rb
+++ b/test/belongs_to_association_test.rb
@@ -24,4 +24,18 @@ class BelongsToAssociationTest < ActiveSupport::TestCase
     assert_equal @user, book.user
     # assert_not_nil User.read_second_level_cache(@user.id)
   end
+
+  def test_should_expire_changed_association_uniq_keys_when_foreign_key_is_symbol
+    reflection = Account.reflect_on_association(:user)
+    assert reflection.belongs_to?
+    assert reflection.foreign_key.is_a?(Symbol)
+
+    account = @user.create_account(site: "foobar")
+    @user.reload.account # Write cache
+    cache_key = Account.send(:cache_uniq_key, reflection.foreign_key => @user.id)
+    assert_equal @user.id, SecondLevelCache.cache_store.read(cache_key)
+
+    account.update_attribute(:user_id, 0)
+    assert_equal nil, SecondLevelCache.cache_store.read(cache_key)
+  end
 end

--- a/test/model/account.rb
+++ b/test/model/account.rb
@@ -9,5 +9,5 @@ end
 
 class Account < ActiveRecord::Base
   second_level_cache expires_in: 3.days
-  belongs_to :user
+  belongs_to :user, foreign_key: :user_id
 end

--- a/test/model/user.rb
+++ b/test/model/user.rb
@@ -35,7 +35,7 @@ class User < ActiveRecord::Base
   serialize :json_options, JSON if ::ActiveRecord::VERSION::STRING >= "4.1.0"
   store :extras, accessors: %i[tagline gender]
 
-  has_one  :account
+  has_one  :account, inverse_of: :user
   has_one  :forked_user_link, foreign_key: "forked_to_user_id"
   has_one  :forked_from_user, through: :forked_user_link
   has_many :namespaces

--- a/test/preloader_test.rb
+++ b/test/preloader_test.rb
@@ -47,20 +47,20 @@ class PreloaderTest < ActiveSupport::TestCase
                         ])
     namespaces = users.map { |user| user.create_namespace(name: user.name) }
 
-    assert_queries(2) { User.includes(:namespace).order(id: :asc).to_a } # Write cache
+    assert_queries(2) { User.includes(:namespace).order(id: :asc).to_a }  # Write cache
     assert_queries(1) do
       assert_equal namespaces, User.includes(:namespace).order(id: :asc).map(&:namespace)
     end
   end
 
-  def test_belongs_to_when_read_multi_missed_from_cache_should_will_fetch_missed_records_from_db
+  def test_has_one_when_read_multi_missed_from_cache_should_will_fetch_missed_records_from_db
     users = User.create([
                           { name: "foobar1", email: "foobar1@test.com" },
                           { name: "foobar2", email: "foobar2@test.com" },
                           { name: "foobar3", email: "foobar3@test.com" }
                         ])
     namespaces = users.map { |user| user.create_namespace(name: user.name) }
-    assert_queries(2) { User.includes(:namespace).order(id: :asc).to_a } # Write cache
+    assert_queries(2) { User.includes(:namespace).order(id: :asc).to_a }  # Write cache
     expired_namespace = namespaces.first
     expired_namespace.expire_second_level_cache
 
@@ -71,6 +71,28 @@ class PreloaderTest < ActiveSupport::TestCase
         assert_equal expired_namespace, results.first.namespace
       end
     end
+  end
+
+  def test_has_one_preloader_returns_correct_records_after_modify
+    user = User.create(name: "foobar", email: "foobar@test.com")
+
+    old_namespace = user.create_namespace(name: "old")
+    assert_queries(2) { User.includes(:namespace).order(id: :asc).to_a }  # Write cache
+    assert_queries(1) do
+      assert_equal old_namespace, User.includes(:namespace).first.namespace
+    end
+
+    new_namespace = user.create_namespace(name: "new")
+    assert_queries(2) { User.includes(:namespace).order(id: :asc).to_a }  # Write cache
+    assert_queries(1) do
+      assert_equal new_namespace, User.includes(:namespace).first.namespace
+    end
+  end
+
+  def test_has_one_preloader_caches_includes_tried_set_inverse_instance
+    User.create(name: "foobar", email: "foobar@test.com").create_account(site: "foobar")
+    users = User.includes(:account)
+    assert_equal users.first.object_id, users.first.account.user.object_id
   end
 
   def test_has_many_preloader_returns_correct_results


### PR DESCRIPTION
1、SecondLevelCache::ActiveRecord::Associations::Preloader::BelongsTo 重命名 SecondLevelCache::ActiveRecord::Associations::Preloader
2、SecondLevelCache::ActiveRecord::Associations::Preloader 增加 has_one 预加载缓存获取
3、Fix expire_changed_association_uniq_keys，当外键是 Symbol 类型时，cache_uniq_key 未失效
4、Fix records_for，预加载没有设置双向关联