### PR TITLE
Fix: preloader if exists default scope

### DIFF
--- a/lib/second_level_cache/active_record/preloader.rb
+++ b/lib/second_level_cache/active_record/preloader.rb
@@ -9,6 +9,7 @@ module SecondLevelCache
         def records_for(ids, &block)
           return super unless klass.second_level_cache_enabled?
           return super unless reflection.is_a?(::ActiveRecord::Reflection::BelongsToReflection)
+          return super if klass.default_scopes.present?
 
           map_cache_keys = ids.map { |id| klass.second_level_cache_key(id) }
           records_from_cache = ::SecondLevelCache.cache_store.read_multi(*map_cache_keys)

--- a/test/model/book.rb
+++ b/test/model/book.rb
@@ -7,10 +7,13 @@ ActiveRecord::Base.connection.create_table(:books, force: true) do |t|
   t.decimal :discount_percentage, precision: 5, scale: 2
   t.integer :images_count, default: 0
   t.date    :publish_date
+  t.boolean :normal, default: true, nil: false
 end
 
 class Book < ActiveRecord::Base
   second_level_cache
+
+  default_scope -> { where(normal: true) }
 
   belongs_to :user, counter_cache: true
   has_many :images, as: :imagable

--- a/test/preloader_belongs_to_test.rb
+++ b/test/preloader_belongs_to_test.rb
@@ -46,4 +46,14 @@ class PreloaderBelongsToTest < ActiveSupport::TestCase
     accounts = Account.includes(:user)
     assert_equal accounts.first.object_id, accounts.first.user.account.object_id
   end
+
+  def test_preloader_from_db_when_exists_scope
+    user = User.create
+    book = user.books.create
+    image = book.images.create
+    book.toggle!(:normal)
+    assert_queries(:any) do
+      assert_nil Image.includes(:imagable).where(id: image.id).first.imagable
+    end
+  end
 end


### PR DESCRIPTION
我觉得，覆盖 ActiveRecord::Relation#exec_queries 方法进行缓存读取判断操作比较好
一是，覆盖了 ActiveRecord::Calculations 之外的所有对象实例化查询，只需维护这一个地方
二是，可以隐式实现 find、find_by、where 这类查询方法的优先从缓存中读取
三是，无需考虑线程安全，直接用 ActiveRecord 提供 skip_query_cache_value 方式替换 without_second_level_cache，也不会造成 uncached 受影响
如果大佬们也赞同的话，新建个分支，我会在空闲时间尝试实现这些转变
@hooopo @huacnlee 
