### PR TITLE
Set cache hit log as debug level

### DIFF
--- a/lib/second_level_cache/active_record/preloader.rb
+++ b/lib/second_level_cache/active_record/preloader.rb
@@ -31,7 +31,7 @@ module SecondLevelCache
           # eg. Rails.cache.read_multi(1,2,3) => {2 => hit_value, 3 => hit_value}
           hitted_ids = record_marshals.map { |record| record.read_attribute(association_key_name).to_s }
           missed_ids = ids.map(&:to_s) - hitted_ids
-          ::SecondLevelCache.logger.info("missed #{association_key_name} -> #{missed_ids.join(',')} | hitted #{association_key_name} -> #{hitted_ids.join(',')}")
+          ::SecondLevelCache.logger.debug("missed #{association_key_name} -> #{missed_ids.join(',')} | hitted #{association_key_name} -> #{hitted_ids.join(',')}")
           return SecondLevelCache::RecordRelation.new(record_marshals) if missed_ids.empty?
 
           records_from_db = super(missed_ids, &block)

--- a/test/finder_methods_test.rb
+++ b/test/finder_methods_test.rb
@@ -62,7 +62,7 @@ class FinderMethodsTest < ActiveSupport::TestCase
   def test_should_fetch_from_db_if_where_use_string
     @user.write_second_level_cache
     assert_queries(:any) do
-      assert_equal nil, User.unscoped.where(id: @user.id).where("name = 'nonexistent'").first
+      assert_nil User.unscoped.where(id: @user.id).where("name = 'nonexistent'").first
     end
     assert_queries(:any) do
       assert_raises ActiveRecord::RecordNotFound do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,7 +33,7 @@ SecondLevelCache.configure do |config|
   config.cache_store = ActiveSupport::Cache::MemoryStore.new
 end
 
-SecondLevelCache.logger.level = Logger::ERROR
+SecondLevelCache.logger.level = Logger::INFO
 ActiveSupport::Cache::MemoryStore.logger = SecondLevelCache.logger
 ActiveRecord::Base.logger = SecondLevelCache.logger
 


### PR DESCRIPTION
修改 cache hit 的日志，改用 `debug` 方式打印，避免 `production` 还会打印。

Rails production 往往是带 RequestId + Date 的单行打印模式，目前会造成很多不必要的输出，cache hit 这个日志开发的时候了解即可。

```
homeland_app     | I, [2020-05-07T07:04:14.851450 #15]  INFO -- : [ActionCable] [dd3c8b56-cada-4345-bb07-6ed2be4f0975] method={} path={} format={} params= controller=NotificationsChannel action=unsubscribe status=200 duration=0.40
homeland_app     | I, [2020-05-07T07:04:14.851918 #15]  INFO -- : [ActionCable] [dd3c8b56-cada-4345-bb07-6ed2be4f0975] method={} path={} format={} params={} controller=ApplicationCable::Connection action=disconnect status=200 duration=0.96
homeland_app     | I, [2020-05-07T07:04:14.967270 #32]  INFO -- : [c541839b-fbb4-4176-abae-515f1aee15ad] method=GET path=/ format=html controller=HomeController action=index status=200 duration=11.31 view=5.95 db=1.34
homeland_app     | I, [2020-05-07T07:04:15.174602 #15]  INFO -- : [66be1784-0ff8-4a4e-bcae-3c50387a223c] method=GET path=/jasl/replies format=*/* controller=UsersController action=replies status=200 duration=92.97 view=65.98 db=22.29
homeland_app     | I, [2020-05-07T07:04:17.259015 #18]  INFO -- : [bbc8a73e-e480-43e5-9469-8c636eda9bf7] missed ids ->  | hitted ids -> 3840
homeland_app     | I, [2020-05-07T07:04:17.321067 #18]  INFO -- : [bbc8a73e-e480-43e5-9469-8c636eda9bf7] method=GET path=/topics/7549 format=*/* controller=TopicsController action=show status=200 duration=66.27 view=57.83 db=1.68
homeland_app     | I, [2020-05-07T07:04:17.803943 #18]  INFO -- : [ActionCable] [5bf120e1-64f0-472f-a9e5-8072844d822e] method={} path={} format={} params={} controller=ApplicationCable::Connection action=connect status=200 duration=0.52
homeland_app     | I, [2020-05-07T07:04:18.208930 #32]  INFO -- : [06c96fdc-b7e8-4fa3-aec5-9f9b06f2575e] missed ids ->  | hitted ids -> 458
homeland_app     | I, [2020-05-07T07:04:18.244474 #32]  INFO -- : [06c96fdc-b7e8-4fa3-aec5-9f9b06f2575e] method=GET path=/topics/21656%0A%0A format=*/* controller=TopicsController action=show status=200 duration=39.76 view=28.66 db=1.50
```