### PR TITLE
fix activerecord association cache

### DIFF
--- a/lib/second_level_cache/active_record.rb
+++ b/lib/second_level_cache/active_record.rb
@@ -12,7 +12,13 @@ require "second_level_cache/active_record/preloader"
 
 # http://api.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html
 # ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
-ActiveSupport.on_load(:active_record) do
+ActiveSupport.on_load(:active_record, run_once: true) do
+  if (Bundler.definition.gem("paranoia") rescue false)
+    require "second_level_cache/adapter/paranoia"
+    include SecondLevelCache::Adapter::Paranoia::ActiveRecord
+    SecondLevelCache::Mixin.send(:prepend, SecondLevelCache::Adapter::Paranoia::Mixin)
+  end
+
   include SecondLevelCache::Mixin
   prepend SecondLevelCache::ActiveRecord::Base
   extend SecondLevelCache::ActiveRecord::FetchByUniqKey

--- a/lib/second_level_cache/active_record/base.rb
+++ b/lib/second_level_cache/active_record/base.rb
@@ -6,11 +6,7 @@ module SecondLevelCache
       def self.prepended(base)
         base.after_commit :update_second_level_cache, on: :update
         base.after_commit :write_second_level_cache, on: :create
-        if defined?(::Paranoia)
-          base.after_destroy :expire_second_level_cache
-        else
-          base.after_commit :expire_second_level_cache, on: :destroy
-        end
+        base.after_commit :expire_second_level_cache, on: :destroy
 
         class << base
           prepend ClassMethods

--- a/lib/second_level_cache/active_record/belongs_to_association.rb
+++ b/lib/second_level_cache/active_record/belongs_to_association.rb
@@ -6,6 +6,9 @@ module SecondLevelCache
       module BelongsToAssociation
         def find_target
           return super unless klass.second_level_cache_enabled?
+          return super if klass.default_scopes.present? || reflection.scope
+          return super if reflection.active_record_primary_key.to_s != klass.primary_key
+
           cache_record = klass.read_second_level_cache(second_level_cache_key)
           if cache_record
             return cache_record.tap { |record| set_inverse_instance(record) }

--- a/lib/second_level_cache/active_record/has_one_association.rb
+++ b/lib/second_level_cache/active_record/has_one_association.rb
@@ -6,7 +6,7 @@ module SecondLevelCache
       module HasOneAssociation
         def find_target
           return super unless klass.second_level_cache_enabled?
-          return super if reflection.scope
+          return super if klass.default_scopes.present? || reflection.scope
           # TODO: implement cache with has_one scope
 
           through = reflection.options[:through]

--- a/lib/second_level_cache/active_record/preloader.rb
+++ b/lib/second_level_cache/active_record/preloader.rb
@@ -9,7 +9,8 @@ module SecondLevelCache
         def records_for(ids, &block)
           return super unless klass.second_level_cache_enabled?
           return super unless reflection.is_a?(::ActiveRecord::Reflection::BelongsToReflection)
-          return super if klass.default_scopes.present?
+          return super if klass.default_scopes.present? || reflection.scope
+          return super if association_key_name.to_s != klass.primary_key
 
           map_cache_keys = ids.map { |id| klass.second_level_cache_key(id) }
           records_from_cache = ::SecondLevelCache.cache_store.read_multi(*map_cache_keys)

--- a/lib/second_level_cache/adapter/paranoia.rb
+++ b/lib/second_level_cache/adapter/paranoia.rb
@@ -1,0 +1,24 @@
+module SecondLevelCache
+  module Adapter
+    module Paranoia
+      module ActiveRecord
+        extend ActiveSupport::Concern
+
+        included do
+          after_destroy :expire_second_level_cache
+        end
+      end
+
+      module Mixin
+        extend ActiveSupport::Concern
+
+        def write_second_level_cache
+          # Avoid rewrite cache again, when record has been soft deleted
+          return if respond_to?(:deleted?) && send(:deleted?)
+          super
+        end
+        alias update_second_level_cache write_second_level_cache
+      end
+    end
+  end
+end

--- a/lib/second_level_cache/mixin.rb
+++ b/lib/second_level_cache/mixin.rb
@@ -71,8 +71,6 @@ module SecondLevelCache
 
     def write_second_level_cache
       return unless klass.second_level_cache_enabled?
-      # Avoid rewrite cache again, when record has been soft deleted
-      return if respond_to?(:deleted?) && send(:deleted?)
 
       marshal = RecordMarshal.dump(self)
       expires_in = klass.second_level_cache_options[:expires_in]

--- a/test/model/paranoid.rb
+++ b/test/model/paranoid.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+ActiveRecord::Base.connection.create_table(:paranoids, force: true) do |t|
+  t.datetime :deleted_at
+end
+
+class Paranoid < ApplicationRecord
+  second_level_cache
+  acts_as_paranoid
+end

--- a/test/model/user.rb
+++ b/test/model/user.rb
@@ -9,7 +9,6 @@ ActiveRecord::Base.connection.create_table(:users, force: true) do |t|
   t.integer :status, default: 0
   t.integer :books_count, default: 0
   t.integer :images_count, default: 0
-  t.datetime :deleted_at
   t.timestamps null: false, precision: 6
 end
 
@@ -29,7 +28,6 @@ end
 class User < ApplicationRecord
   CACHE_VERSION = 3
   second_level_cache(version: CACHE_VERSION, expires_in: 3.days)
-  acts_as_paranoid
 
   serialize :options, Array
   serialize :json_options, JSON if ::ActiveRecord::VERSION::STRING >= "4.1.0"

--- a/test/paranoid_test.rb
+++ b/test/paranoid_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ParanoidTest < ActiveSupport::TestCase
+  def setup
+    @paranoid = Paranoid.create
+  end
+
+  def test_should_expire_cache_when_destroy
+    @paranoid.destroy
+    assert_nil Paranoid.find_by(id: @paranoid.id)
+    assert_nil SecondLevelCache.cache_store.read(@paranoid.second_level_cache_key)
+    assert_nil User.read_second_level_cache(@paranoid.id)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,7 @@ require "model/order_item"
 require "model/account"
 require "model/animal"
 require "model/contribution"
+require "model/paranoid"
 
 DatabaseCleaner[:active_record].strategy = :truncation
 


### PR DESCRIPTION
- 修正 `Preloader/HasOneAssociation/BelongsToAssociation` 缓存条件
- `paranoia` 适配单独剥离，只在需要时加入