### PR TITLE
remove AR touch method override

### DIFF
--- a/lib/second_level_cache/active_record/persistence.rb
+++ b/lib/second_level_cache/active_record/persistence.rb
@@ -17,10 +17,6 @@ module SecondLevelCache
         expire_second_level_cache
         super
       end
-
-      def touch(*names, **opts)
-        super.tap { update_second_level_cache }
-      end
     end
   end
 end


### PR DESCRIPTION
Activerecord touch 方法是会执行 commit 回调的，我们没必要覆写它