### PR TITLE
Fix typo `id` to `ids` in find_some_with_second_level_cache

### DIFF
--- a/lib/second_level_cache/active_record/finder_methods.rb
+++ b/lib/second_level_cache/active_record/finder_methods.rb
@@ -39,8 +39,8 @@ module SecondLevelCache
       end
 
       def find_some_with_second_level_cache(ids)
-        return find_some_without_second_level_cache(id) unless second_level_cache_enabled?
-        return find_some_without_second_level_cache(id) unless select_all_column?
+        return find_some_without_second_level_cache(ids) unless second_level_cache_enabled?
+        return find_some_without_second_level_cache(ids) unless select_all_column?
 
         if cachable?
           result = multi_read_from_cache(ids)

--- a/second_level_cache.gemspec
+++ b/second_level_cache.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "activesupport", ["> 4.0.0", "< 5.0"]
 
   gem.add_runtime_dependency "activerecord", ["> 4.0.0", "< 5.0"]
-  gem.add_development_dependency "sqlite3"
+  gem.add_development_dependency "sqlite3", "~> 1.3.6"
   gem.add_development_dependency "rake"
   gem.add_development_dependency 'pry'
   gem.add_development_dependency "database_cleaner", "~> 1.3.0"

--- a/test/finder_methods_test.rb
+++ b/test/finder_methods_test.rb
@@ -48,6 +48,13 @@ class FinderMethodsTest < ActiveSupport::TestCase
     assert_equal 2, @users.size
   end
 
+  def test_find_some_record_without_second_level_cache
+    User.without_second_level_cache do
+      @users = User.find(@user.id, @other_user.id)
+    end
+    assert_equal 2, @users.size
+  end
+
   def test_missing_id_will_raise_for_find_some
     assert_raises(ActiveRecord::RecordNotFound) do
       @users = User.find(@user.id, User.last.id + 10000)


### PR DESCRIPTION
Occur exception when find some record without SLC:

```
  1) Error:
FinderMethodsTest#test_find_some_record_without_second_level_cache:
NameError: undefined local variable or method `id' for #<ActiveRecord::Relation []>
Did you mean?  ids
    /path/to/gems/activerecord-4.2.11.3/lib/active_record/relation/delegation.rb:136:in `method_missing'
    /path/to/gems/activerecord-4.2.11.3/lib/active_record/relation/delegation.rb:99:in `method_missing'
    /path/to/second_level_cache/lib/second_level_cache/active_record/finder_methods.rb:42:in `find_some_with_second_level_cache'
    /path/to/gems/activerecord-4.2.11.3/lib/active_record/relation/finder_methods.rb:426:in `find_with_ids'
    /path/to/gems/activerecord-4.2.11.3/lib/active_record/relation/finder_methods.rb:71:in `find'
    /path/to/gems/activerecord-4.2.11.3/lib/active_record/querying.rb:3:in `find'
    /path/to/gems/activerecord-4.2.11.3/lib/active_record/core.rb:128:in `find'
    /path/to/second_level_cache/lib/second_level_cache/active_record/core.rb:17:in `find_with_cache'
    /path/to/second_level_cache/test/finder_methods_test.rb:53:in `block in test_find_some_record_without_second_level_cache'
    /path/to/second_level_cache/lib/second_level_cache.rb:37:in `without_second_level_cache'
    /path/to/second_level_cache/test/finder_methods_test.rb:52:in `test_find_some_record_without_second_level_cache'
```

This is reason that mistakenly used `id` instead of `ids` in `find_some_with_second_level_cache` when `unless second_level_cache_enabled?` or `unless select_all_column?`.
So, fixed it and added test.