### PR TITLE
修正 has_one through 选项的关联反射查找对象

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 *.lock
 vendor/bundle
 .idea
+.ruby-version

--- a/lib/second_level_cache/active_record/has_one_association.rb
+++ b/lib/second_level_cache/active_record/has_one_association.rb
@@ -11,8 +11,7 @@ module SecondLevelCache
 
           through = reflection.options[:through]
           record  = if through
-            return super if klass.reflections[through.to_s].nil?
-            return super unless klass.reflections[through.to_s].klass.second_level_cache_enabled?
+            return super unless owner.class.reflections[through.to_s].klass.second_level_cache_enabled?
             begin
               reflection.klass.find(owner.send(through).read_attribute(reflection.foreign_key))
             rescue StandardError


### PR DESCRIPTION
```
class Hotspot < ApplicationRecord
  belongs_to :post, required: false
  has_one :topic, through: :post
end
```
`post` 和 `topic` 都是 `Hotspot` 定义的 `reflection`，不存在找不到的可能