### PR TITLE
Fixed check cache_enabled? function when rails app set cache null store.

### DIFF
--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -22,6 +22,9 @@ module SecondLevelCache
   end
 
   def self.cache_enabled?
+    if self.cache_store.is_a?(ActiveSupport::Cache::NullStore)
+      return false
+    end
     cache_enabled = Thread.current[:slc_cache_enabled]
     cache_enabled.nil? ? true : cache_enabled
   end


### PR DESCRIPTION
This issue will raise rails app got exception `NameError`, for example https://github.com/ruby-china/homeland/issues/1313   if config cache_store to :null_store: `config.cache_store = :null_store`